### PR TITLE
Fix file processing cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,10 @@ class DummyS3:
             raise self.exceptions.ClientError({"Error": {"Code": "404"}}, "head_object")
         return {}
 
+    def delete_object(self, Bucket, Key):
+        self.objects.pop((Bucket, Key), None)
+        return {}
+
     def get_object_tagging(self, Bucket, Key):
         tagset = [
             {"Key": k, "Value": v}

--- a/tests/test_file_processing_lambda.py
+++ b/tests/test_file_processing_lambda.py
@@ -36,3 +36,5 @@ def test_file_processing_lambda(monkeypatch, s3_stub, config):
     assert body['document_id'] == 'test'
     assert body['s3_location'] == 's3://dest-bucket/raw/test.docx'
     assert body['collection_name'] == 'c'
+    # ensure the source file was removed after processing
+    assert ('bucket', 'path/test.docx') not in s3_stub.objects

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1111,7 +1111,7 @@ def test_vector_search_guid_filter(monkeypatch, config):
     assert len(res["matches"]) == 1 and res["matches"][0]["metadata"]["file_guid"] == "g2"
 
 
-def test_file_processing_passthrough(monkeypatch):
+def test_file_processing_passthrough(monkeypatch, s3_stub):
     module = load_lambda(
         "file_proc2", "services/file-ingestion/file-processing-lambda/app.py"
     )


### PR DESCRIPTION
## Summary
- remove file from source bucket after copying to IDP bucket
- include s3 delete in DummyS3 test helper
- assert file removal in file processing tests
- ensure file-processing passthrough tests patch S3

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686756cf9818832faeb42a7dbfb12faa