### PR TITLE
Use ML for prompt complexity in router

### DIFF
--- a/services/llm-router/router-lambda/app.py
+++ b/services/llm-router/router-lambda/app.py
@@ -22,6 +22,7 @@ import json
 from common_utils import configure_logger
 from models import LlmRouterEvent, LambdaResponse
 from main_router import route_event
+from predictive_router import invoke_classifier
 
 __author__ = "Koushik Sinha"
 __version__ = "1.0.0"
@@ -58,6 +59,17 @@ def _sanitize_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     return payload
 def _choose_backend(prompt: str) -> str:
     """Return which backend to use based on prompt complexity."""
+    classifier_model = os.environ.get("CLASSIFIER_MODEL_ID") or os.environ.get("WEAK_MODEL_ID")
+    if classifier_model:
+        try:
+            result = invoke_classifier(boto3.client("lambda"), classifier_model, prompt)
+            if result == "complex":
+                return "bedrock"
+            if result == "simple":
+                return "ollama"
+        except Exception as exc:  # pragma: no cover - ML model failure
+            logger.exception("Classifier error: %s", exc)
+
     complexity = len(prompt.split())
     if complexity >= PROMPT_COMPLEXITY_THRESHOLD:
         return "bedrock"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -698,7 +698,13 @@ import sys
 
 def test_llm_router_choose_backend(monkeypatch):
     monkeypatch.setenv("PROMPT_COMPLEXITY_THRESHOLD", "3")
+    monkeypatch.setenv("CLASSIFIER_MODEL_ID", "x")
     module = load_lambda("llm_router_app", "services/llm-router/router-lambda/app.py")
+    monkeypatch.setattr(
+        module,
+        "invoke_classifier",
+        lambda client, model, prompt: "complex" if len(prompt.split()) > 3 else "simple",
+    )
     assert module._choose_backend("one two") == "ollama"
     assert module._choose_backend("one two three four") == "bedrock"
 
@@ -759,8 +765,14 @@ def test_llm_router_lambda_handler_backend_override(monkeypatch):
 
 def test_llm_router_choose_backend_default(monkeypatch):
     monkeypatch.delenv("PROMPT_COMPLEXITY_THRESHOLD", raising=False)
+    monkeypatch.setenv("CLASSIFIER_MODEL_ID", "x")
     module = load_lambda(
         "llm_router_app_default", "services/llm-router/router-lambda/app.py"
+    )
+    monkeypatch.setattr(
+        module,
+        "invoke_classifier",
+        lambda client, model, prompt: "complex" if len(prompt.split()) > 20 else "simple",
     )
     short_prompt = " ".join(["w"] * 5)
     long_prompt = " ".join(["w"] * 25)

--- a/tests/test_router_lambda.py
+++ b/tests/test_router_lambda.py
@@ -21,7 +21,13 @@ def _make_fake_send(calls):
 
 def test_choose_backend(monkeypatch):
     monkeypatch.setenv("PROMPT_COMPLEXITY_THRESHOLD", "3")
+    monkeypatch.setenv("CLASSIFIER_MODEL_ID", "x")
     module = load_lambda("router_app", "services/llm-router/router-lambda/app.py")
+    monkeypatch.setattr(
+        module,
+        "invoke_classifier",
+        lambda client, model, prompt: "complex" if len(prompt.split()) > 3 else "simple",
+    )
     assert module._choose_backend("a b") == "ollama"
     assert module._choose_backend("a b c d") == "bedrock"
 


### PR DESCRIPTION
## Summary
- switch `_choose_backend` to use ML classifier when available
- adjust router tests for new classifier-based logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675ce7ff88832fa7a7df367b062422