### PR TITLE
Improve logging consistency

### DIFF
--- a/services/file-assembly/file-assemble-lambda/app.py
+++ b/services/file-assembly/file-assemble-lambda/app.py
@@ -63,10 +63,10 @@ def upload_to_s3(pdf_bytes: bytes, file_name: str, bucket_name: str, s3_client=s
         response = s3_client.put_object(
             Bucket=bucket_name, Key=bucket_file_name, Body=pdf_bytes, ContentType="application/pdf"
         )
-        logger.info(f"Uploaded file {bucket_file_name} to S3 successfully.")
+        logger.info("Uploaded file %s to S3 successfully.", bucket_file_name)
         return {"summarized_file": f"s3://{bucket_name}/{bucket_file_name}"}
     except Exception as e:
-        logger.error(f"Error uploading to S3: {str(e)}")
+        logger.error("Error uploading to S3: %s", str(e))
         raise ValueError(f"Failed to upload PDF to S3")
 
 
@@ -93,12 +93,12 @@ def assemble_files(event: FileAssemblyEvent, context, s3_client=s3_client) -> Fi
         organic_bucket_key = event_body["organic_bucket_key"]
         summary_bucket_name = event_body["summary_bucket_name"]
         summary_bucket_key = event_body["summary_bucket_key"]
-        logger.info(f"Getting file details from S3: {organic_bucket_name}/{organic_bucket_key}")
+        logger.info("Getting file details from S3: %s/%s", organic_bucket_name, organic_bucket_key)
         organic_response = s3_client.get_object(Bucket=organic_bucket_name, Key=organic_bucket_key)
-        logger.info(f"GOT THE FILE DETAILS FROM THE S3: {organic_bucket_name}/{organic_bucket_key}")
+        logger.info("GOT THE FILE DETAILS FROM THE S3: %s/%s", organic_bucket_name, organic_bucket_key)
         organic_file_content = organic_response["Body"].read()
         summary_response = s3_client.get_object(Bucket=summary_bucket_name, Key=summary_bucket_key)
-        logger.info(f"GOT THE FILE DETAILS FROM THE S3: {summary_bucket_name}/{summary_bucket_key}")
+        logger.info("GOT THE FILE DETAILS FROM THE S3: %s/%s", summary_bucket_name, summary_bucket_key)
         summary_file_content = summary_response["Body"].read()
 
         organic_file_key = event_body['organic_bucket_key']
@@ -107,7 +107,7 @@ def assemble_files(event: FileAssemblyEvent, context, s3_client=s3_client) -> Fi
 
         ext = os.path.splitext(organic_file_key)[1].lower()
         if ext == '.pdf':
-            logger.info(f"Merging PDFs: {merged_file_key}")
+            logger.info("Merging PDFs: %s", merged_file_key)
             merged_pdf_bytes = merge_pdfs(summary_file_content, organic_file_content)
             final_response = upload_to_s3(merged_pdf_bytes, merged_file_key, organic_bucket_name, s3_client)
             final_response['merged'] = True
@@ -117,7 +117,7 @@ def assemble_files(event: FileAssemblyEvent, context, s3_client=s3_client) -> Fi
             final_response['merged'] = False
         return final_response
     except Exception as e:
-        logger.error(f"Error assembling files: {str(e)}")
+        logger.error("Error assembling files: %s", str(e))
         raise ValueError(f"Failed to assemble PDFs")
 
 
@@ -148,7 +148,7 @@ def merge_pdfs(summary_file_content: bytes, organic_file_content: bytes) -> Opti
         merge_pdf.seek(0)
         return merge_pdf.read()
     except Exception as e:
-        logger.error(f"Error merging PDFs: {str(e)}")
+        logger.error("Error merging PDFs: %s", str(e))
         raise ValueError(f"Failed to merge PDFs")
 
 
@@ -180,6 +180,6 @@ def lambda_handler(event: FileAssemblyEvent, context) -> LambdaResponse:
         final_response = assemble_files(event, context, s3_client)
         return _response(200, final_response)
     except Exception as e:
-        logger.error(f"Error in Lambda handler: {str(e)}")
+        logger.error("Error in Lambda handler: %s", str(e))
         response_body = f"Error occurred: {str(e)}"
         return _response(500, {"error": response_body})

--- a/services/file-ingestion/file-processing-status-lambda/app.py
+++ b/services/file-ingestion/file-processing-status-lambda/app.py
@@ -96,7 +96,7 @@ def lambda_handler(event: ProcessingStatusEvent | dict, context) -> dict:
                 logger.exception("Invalid request to lambda_handler")
                 return _response(400, {"statusMessage": str(exc)})
         body = check_file_processing_status(event, context)
-        logger.info(f"Returning final response: {body}")
+        logger.info("Returning final response: %s", body)
         return _response(200, body)
     except Exception as e:
         logger.exception("lambda_handler failed")

--- a/services/summarization/file-summary-lambda/app.py
+++ b/services/summarization/file-summary-lambda/app.py
@@ -378,7 +378,7 @@ def process_for_summary(event: SummaryEvent, context: Any) -> Dict[str, Any]:
         organic_bucket_name = event_body['organic_bucket']
         summary_file_key = organic_file_key.replace('extracted', 'summary')
         summary_file_key = os.path.splitext(summary_file_key)[0] + f".{ext}"
-        logger.info(f"organic_file_key:{organic_file_key}")
+        logger.info("organic_file_key:%s", organic_file_key)
         #new_folder_name = organic_file_folder[1]
         upload_buffer_to_s3(summary_buf, organic_bucket_name, summary_file_key, ctype)
 

--- a/services/zip-processing/zip-creation-lambda/app.py
+++ b/services/zip-processing/zip-creation-lambda/app.py
@@ -51,10 +51,10 @@ def get_values_from_ssm(ssm_key: str) -> str:
             WithDecryption=False
         )
         if response['Parameter']['Value']:
-            logger.info(f"Parameter Value for {ssm_key}: {response['Parameter']['Value']}")
+            logger.info("Parameter Value for %s: %s", ssm_key, response['Parameter']['Value'])
             return response['Parameter']['Value']
         else:
-            logger.warning(f"No value found for parameter: {ssm_key}")
+            logger.warning("No value found for parameter: %s", ssm_key)
             return None
     except Exception as e:
         raise ValueError(f"Error occurred while retrieving parameter: {e}")
@@ -118,7 +118,7 @@ def extract_dynamic_path(path):
 
     # Define the length of the dynamic prefix
     prefix_length = 8  # Length of "2025/06/23/20/16/29"
-    logger.info(f"path:{path}")
+    logger.info("path:%s", path)
     # Split the path by '/'
     parts = path.split('/')
     
@@ -147,7 +147,7 @@ def assemble_zip_files(event, s3_client=s3_client):
     # Get the zip file name
     zip_file_name = event['zipFileName']
     zip_file_name = zip_file_name.split("/")[-1]
-    logger.info(f"zip_file_name:{zip_file_name}")
+    logger.info("zip_file_name:%s", zip_file_name)
     zip_file_name = f"curated/{zip_file_name}"
 
     pdf_files = [file['pdffile'] for file in event.get('pdfFiles', [])]
@@ -163,7 +163,7 @@ def assemble_zip_files(event, s3_client=s3_client):
             bucket_name, file_key, file_name = parse_s3_uri(xml_file)
             response = s3_client.get_object(Bucket=bucket_name, Key=f"{file_key}/{file_name}")
             file_name = extract_dynamic_path(file_name)
-            logger.info(f"file_name:{file_name}")
+            logger.info("file_name:%s", file_name)
             output_zip.writestr(file_name, response['Body'].read())
         # Check if Output is present and summarized_file exists
         for file in event.get("files", []):
@@ -180,7 +180,7 @@ def assemble_zip_files(event, s3_client=s3_client):
                   response = s3_client.get_object(Bucket=bucket_name, Key=f"{file_key}/{file_name}")
 
                   file_name = extract_dynamic_path(file_name)
-                  logger.info(f"file_name:{file_name}")
+                  logger.info("file_name:%s", file_name)
                   output_zip.writestr(file_name, response['Body'].read())
 
         for pdf_file in pdf_files:
@@ -190,7 +190,7 @@ def assemble_zip_files(event, s3_client=s3_client):
             if parts[0] not in processedFiles:
               response = s3_client.get_object(Bucket=bucket_name, Key=f"{file_key}/{file_name}")
               file_name = extract_dynamic_path(file_name)
-              logger.info(f"file_name:{file_name}")
+              logger.info("file_name:%s", file_name)
               output_zip.writestr(file_name, response['Body'].read())
     # Save the zip file to S3
     output_zip_stream.seek(0)
@@ -204,7 +204,7 @@ def assemble_zip_files(event, s3_client=s3_client):
             Body=output_zip_stream.getvalue(),
         )
     except ClientError as e:
-        logger.error(f"Failed to upload zip file to S3: {e}")
+        logger.error("Failed to upload zip file to S3: %s", e)
         return {
             "statusCode": 500,
             "error": "Failed to upload zip file",
@@ -226,8 +226,8 @@ def assemble_zip_files(event, s3_client=s3_client):
                     pdf_file_name =f"{xml_file_name}.pdf"
                     unprocessedFileMessage.append((xml_tag_content["PolNumber"],xml_tag_content["TrackingID"],pdf_file_name) )  
             except ClientError as e:
-                logger.error(f"Failed to retrieve XML from S3: {e}")   
-                raise e 
+                logger.error("Failed to retrieve XML from S3: %s", e)
+                raise e
 
     try:
          if unprocessedFileMessage:

--- a/services/zip-processing/zip-extract-lambda/app.py
+++ b/services/zip-processing/zip-extract-lambda/app.py
@@ -166,7 +166,7 @@ def extract_zip_file(event: dict) -> dict:
                     continue
                 if info.filename.lower().endswith(".pdf") or info.filename.lower().endswith(".xml"):
                     s3_key = f"{extracted_file_key}{info.filename}"
-                    logger.info(f"s3_key:{s3_key}")
+                    logger.info("s3_key:%s", s3_key)
                     with zf.open(info) as file_obj:
                         uploadedFilePath = upload_to_s3(
                             destination_bucket_name, s3_key, file_obj
@@ -182,7 +182,7 @@ def extract_zip_file(event: dict) -> dict:
                 else:
                     # Place in a folder named after the ZIP file
                     s3_key = f'{extracted_file_key}/{zip_file_name}/{info.filename}'
-                logger.info(f"s3_key:{s3_key}")
+                logger.info("s3_key:%s", s3_key)
                 with zf.open(info) as file_obj:
                     xmlUploadedPath = upload_to_s3(destination_bucket_name, s3_key, file_obj)
                     xmlfileList.append(xmlUploadedPath)"""


### PR DESCRIPTION
## Summary
- standardize logger usage across Lambda apps
- use parameterized logging instead of f-strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686768d2b9dc832f8b59fcb2e5753314