### PR TITLE
Refactor _response helper into shared module

### DIFF
--- a/common/layers/common-utils/python/common_utils/__init__.py
+++ b/common/layers/common-utils/python/common_utils/__init__.py
@@ -13,6 +13,7 @@ from .get_ssm import (
 from .milvus_client import MilvusClient, VectorItem, SearchResult, GetResult
 from .elasticsearch_client import ElasticsearchClient
 from .entity_extraction import extract_entities
+from .lambda_response import lambda_response
 
 __all__ = [
     "get_values_from_ssm",
@@ -26,4 +27,5 @@ __all__ = [
     "ElasticsearchClient",
     "extract_entities",
     "configure_logger",
+    "lambda_response",
 ]

--- a/common/layers/common-utils/python/common_utils/lambda_response.py
+++ b/common/layers/common-utils/python/common_utils/lambda_response.py
@@ -1,0 +1,10 @@
+"""Utilities for building Lambda-style HTTP responses."""
+
+from typing import Any, Dict
+
+__all__ = ["lambda_response"]
+
+
+def lambda_response(status: int, body: Any) -> Dict[str, Any]:
+    """Return a standard Lambda response dictionary."""
+    return {"statusCode": status, "body": body}

--- a/services/file-assembly/file-assemble-lambda/app.py
+++ b/services/file-assembly/file-assemble-lambda/app.py
@@ -20,7 +20,7 @@ Modified By: Koushik Sinha
 from __future__ import annotations
 import json
 import logging
-from common_utils import configure_logger
+from common_utils import configure_logger, lambda_response
 import os
 import boto3
 from PyPDF2 import PdfReader, PdfWriter
@@ -152,9 +152,6 @@ def merge_pdfs(summary_file_content: bytes, organic_file_content: bytes) -> Opti
         raise ValueError(f"Failed to merge PDFs")
 
 
-def _response(status: int, body: dict) -> dict:
-    """Helper to build a consistent Lambda response."""
-    return {"statusCode": status, "body": body}
 
 
 def lambda_handler(event: FileAssemblyEvent, context) -> LambdaResponse:
@@ -178,8 +175,8 @@ def lambda_handler(event: FileAssemblyEvent, context) -> LambdaResponse:
     logger.info("Starting Lambda function...")
     try:
         final_response = assemble_files(event, context, s3_client)
-        return _response(200, final_response)
+        return lambda_response(200, final_response)
     except Exception as e:
         logger.error("Error in Lambda handler: %s", str(e))
         response_body = f"Error occurred: {str(e)}"
-        return _response(500, {"error": response_body})
+        return lambda_response(500, {"error": response_body})

--- a/services/file-ingestion/file-processing-status-lambda/app.py
+++ b/services/file-ingestion/file-processing-status-lambda/app.py
@@ -16,7 +16,7 @@ Modified By: Koushik Sinha
 from __future__ import annotations
 import boto3
 import logging
-from common_utils import configure_logger
+from common_utils import configure_logger, lambda_response
 import os
 from models import ProcessingStatusEvent
 from common_utils.get_ssm import (
@@ -72,9 +72,6 @@ def check_file_processing_status(event: ProcessingStatusEvent, context) -> dict:
     return event_body
 
 
-def _response(status: int, body: dict) -> dict:
-    """Helper to build a consistent Lambda response."""
-    return {"statusCode": status, "body": body}
 
 
 def lambda_handler(event: ProcessingStatusEvent | dict, context) -> dict:
@@ -94,10 +91,10 @@ def lambda_handler(event: ProcessingStatusEvent | dict, context) -> dict:
                 event = ProcessingStatusEvent.from_dict(event)
             except ValueError as exc:
                 logger.exception("Invalid request to lambda_handler")
-                return _response(400, {"statusMessage": str(exc)})
+                return lambda_response(400, {"statusMessage": str(exc)})
         body = check_file_processing_status(event, context)
         logger.info("Returning final response: %s", body)
-        return _response(200, body)
+        return lambda_response(200, body)
     except Exception as e:
         logger.exception("lambda_handler failed")
-        return _response(500, {"statusMessage": str(e)})
+        return lambda_response(500, {"statusMessage": str(e)})

--- a/services/llm-invocation/invoke-lambda/app.py
+++ b/services/llm-invocation/invoke-lambda/app.py
@@ -11,7 +11,7 @@ routing strategies can delegate all model interactions here.
 from __future__ import annotations
 
 import logging
-from common_utils import configure_logger
+from common_utils import configure_logger, lambda_response
 from typing import Any, Dict
 from models import LlmInvocationEvent, LambdaResponse
 
@@ -30,11 +30,6 @@ __version__ = "1.0.0"
 __modified_by__ = "Koushik Sinha"
 
 logger = configure_logger(__name__)
-
-
-def _response(status: int, body: dict) -> dict:
-    """Helper to build a consistent Lambda response."""
-    return {"statusCode": status, "body": body}
 
 
 
@@ -88,7 +83,7 @@ def _process_event(event: LlmInvocationEvent) -> LambdaResponse:
         logger.error(
             "LLM request failed [%d]: %s", exc.response.status_code, exc.response.text
         )
-        return _response(
+        return lambda_response(
             500,
             {
                 "error": f"{exc.response.status_code}: {exc.response.text}",
@@ -96,7 +91,7 @@ def _process_event(event: LlmInvocationEvent) -> LambdaResponse:
         )
     except Exception as exc:  # pragma: no cover - unexpected failures
         logger.exception("Unexpected error in llm invocation")
-        return _response(500, {"error": str(exc)})
+        return lambda_response(500, {"error": str(exc)})
 
 
 def lambda_handler(event: LlmInvocationEvent, context: Any) -> Any:

--- a/services/summarization/file-summary-lambda/app.py
+++ b/services/summarization/file-summary-lambda/app.py
@@ -19,7 +19,7 @@ Modified By: Koushik Sinha
 
 from __future__ import annotations
 
-from common_utils import configure_logger
+from common_utils import configure_logger, lambda_response
 import re
 import os
 from io import BytesIO
@@ -405,9 +405,6 @@ def process_for_summary(event: SummaryEvent, context: Any) -> Dict[str, Any]:
         return {"statusCode": 500, "statusMessage": "Internal server error"}
 
 
-def _response(status: int, body: Dict[str, Any]) -> Dict[str, Any]:
-    """Helper to build a consistent Lambda response."""
-    return {"statusCode": status, "body": body}
 
 
 def lambda_handler(event: SummaryEvent | Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -425,16 +422,16 @@ def lambda_handler(event: SummaryEvent | Dict[str, Any], context: Any) -> Dict[s
                 event = SummaryEvent.from_dict(event)
             except ValueError as exc:
                 logger.exception("Invalid request to lambda_handler")
-                return _response(400, {"statusMessage": str(exc)})
+                return lambda_response(400, {"statusMessage": str(exc)})
         body = process_for_summary(event, context)
         status = body.get("statusCode", 200)
-        return _response(status, body)
+        return lambda_response(status, body)
     except (ClientError, BotoCoreError) as exc:
         logger.exception("AWS error invoking Lambda")
-        return _response(502, {"statusMessage": "AWS service error"})
+        return lambda_response(502, {"statusMessage": "AWS service error"})
     except ValueError as exc:
         logger.exception("Invalid request to lambda_handler")
-        return _response(400, {"statusMessage": str(exc)})
+        return lambda_response(400, {"statusMessage": str(exc)})
     except Exception as exc:
         logger.exception("lambda_handler failed")
-        return _response(500, {"statusMessage": "Internal server error"})
+        return lambda_response(500, {"statusMessage": "Internal server error"})


### PR DESCRIPTION
## Summary
- centralize Lambda HTTP response formatting in `common_utils`
- use `lambda_response` across ingestion, assembly, invocation and summarization services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676bbca370832f9e4dcfffe8392519