### PR TITLE
Bump PyPDF2 to latest stable version

### DIFF
--- a/common/layers/file-assemble-lambda-layer/requirements.txt
+++ b/common/layers/file-assemble-lambda-layer/requirements.txt
@@ -1,4 +1,4 @@
-PyPDF2==3.0.1
+PyPDF2==3.0.2
 boto3==1.35.53
 fpdf2==2.8.2
 Unidecode


### PR DESCRIPTION
## Summary
- update PyPDF2 requirement to 3.0.2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676fe293e0832f8f34073f788d8eda