### PR TITLE
Add secret helper and integrate with services

### DIFF
--- a/common/layers/common-utils/python/common_utils/__init__.py
+++ b/common/layers/common-utils/python/common_utils/__init__.py
@@ -10,6 +10,7 @@ from .get_ssm import (
     parse_s3_uri,
     get_config,
 )
+from .get_secret import get_secret
 from .milvus_client import MilvusClient, VectorItem, SearchResult, GetResult
 from .elasticsearch_client import ElasticsearchClient
 from .entity_extraction import extract_entities
@@ -20,6 +21,7 @@ __all__ = [
     "get_environment_prefix",
     "parse_s3_uri",
     "get_config",
+    "get_secret",
     "MilvusClient",
     "VectorItem",
     "SearchResult",

--- a/common/layers/common-utils/python/common_utils/get_secret.py
+++ b/common/layers/common-utils/python/common_utils/get_secret.py
@@ -1,0 +1,40 @@
+"""Helper to load secrets from AWS Secrets Manager."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import boto3
+
+from common_utils import configure_logger
+
+logger = configure_logger(__name__)
+
+_secrets_client = boto3.client("secretsmanager")
+
+# Cache so a Lambda invocation only fetches each secret once
+_SECRET_CACHE: dict[str, str] = {}
+
+
+def get_secret(name: str) -> Optional[str]:
+    """Return the value of secret ``name`` from Secrets Manager.
+
+    The secret name can be overridden by setting an environment variable
+    ``<name>_SECRET_NAME`` (for example ``COHERE_SECRET_NAME``). The first
+    request fetches the value from AWS and caches it for subsequent calls.
+    """
+    secret_name = os.environ.get(f"{name}_SECRET_NAME", name)
+    if secret_name in _SECRET_CACHE:
+        return _SECRET_CACHE[secret_name]
+    try:
+        resp = _secrets_client.get_secret_value(SecretId=secret_name)
+        value = resp.get("SecretString")
+        if value is None:
+            value = resp.get("SecretBinary", b"").decode("utf-8")
+        _SECRET_CACHE[secret_name] = value
+        logger.info("Loaded secret %s", secret_name)
+        return value
+    except Exception as exc:
+        logger.error("Error retrieving secret %s: %s", secret_name, exc)
+        raise

--- a/common/layers/llm-invocation-layer/python/llm_invocation/backends.py
+++ b/common/layers/llm-invocation-layer/python/llm_invocation/backends.py
@@ -12,10 +12,12 @@ import boto3
 import httpx
 import asyncio
 from common_utils import configure_logger
+from common_utils.get_secret import get_secret
 
 logger = configure_logger(__name__)
 
-BEDROCK_API_KEY = os.environ.get("BEDROCK_API_KEY")
+_secret_name = os.environ.get("BEDROCK_SECRET_NAME", "BEDROCK_API_KEY")
+BEDROCK_API_KEY = get_secret(_secret_name)
 OLLAMA_DEFAULT_MODEL = os.environ.get("OLLAMA_DEFAULT_MODEL", "")
 
 # Default sampling parameters for Bedrock models

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -37,7 +37,7 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `EMBED_MODEL_MAP` – JSON mapping of document types to models.
 - `SBERT_MODEL` – SentenceTransformer model path or name.
 - `OPENAI_EMBED_MODEL` – embedding model for OpenAI.
-- `COHERE_API_KEY` – API key for Cohere embeddings.
+- `COHERE_SECRET_NAME` – name or ARN of the Cohere API key secret.
 
 ### Vector DB
 
@@ -58,15 +58,16 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `ROUTELLM_ENDPOINT` – LLM router URL.
 - `EMBED_MODEL` / `SBERT_MODEL` – embedding configuration.
 - `OPENAI_EMBED_MODEL` – OpenAI model name.
-- `COHERE_API_KEY` – Cohere API key.
+- `COHERE_SECRET_NAME` – name or ARN of the Cohere API key secret.
 - `RERANK_FUNCTION` – optional Lambda used to re-rank search results.
 - `RERANK_PROVIDER` – provider for the re-ranking model.
+- `NVIDIA_SECRET_NAME` – name or ARN of the NVIDIA API key secret.
 - `VECTOR_SEARCH_CANDIDATES` – number of search results retrieved before re-ranking.
 
 ### LLM Router and Invocation
 
 - `BEDROCK_OPENAI_ENDPOINTS` – comma‑separated Bedrock endpoints.
-- `BEDROCK_API_KEY` – API key for Bedrock.
+- `BEDROCK_SECRET_NAME` – name or ARN of the Bedrock API key secret.
 - `BEDROCK_TEMPERATURE`, `BEDROCK_NUM_CTX`, `BEDROCK_MAX_TOKENS`, `BEDROCK_TOP_P`, `BEDROCK_TOP_K`, `BEDROCK_MAX_TOKENS_TO_SAMPLE` – generation settings for Bedrock.
 - `OLLAMA_ENDPOINTS` – comma‑separated URLs of Ollama servers.
 - `OLLAMA_DEFAULT_MODEL` – default Ollama model name.

--- a/docs/router_configuration.md
+++ b/docs/router_configuration.md
@@ -7,7 +7,7 @@ This document details the environment variables used by the router Lambda and ho
 | Name | Description |
 | ---- | ----------- |
 | `BEDROCK_OPENAI_ENDPOINTS` | Comma‑separated Bedrock endpoints implementing the OpenAI API. |
-| `BEDROCK_API_KEY` | API key to authenticate when calling Bedrock. |
+| `BEDROCK_SECRET_NAME` | Name or ARN of the Bedrock API key secret. |
 | `BEDROCK_TEMPERATURE` | Sampling temperature for Bedrock models (default `0.5`). |
 | `BEDROCK_NUM_CTX` | Context length for Bedrock calls (default `4096`). |
 | `BEDROCK_MAX_TOKENS` | Maximum tokens to generate (default `2048`). |

--- a/services/llm-invocation/README.md
+++ b/services/llm-invocation/README.md
@@ -16,7 +16,7 @@ Parameters defined in `template.yaml` map directly to environment variables used
 
 ### Bedrock options
 - `BEDROCK_OPENAI_ENDPOINTS` – comma-separated endpoints for the Bedrock OpenAI API.
-- `BEDROCK_API_KEY` – API key used when contacting Bedrock.
+ - `BEDROCK_SECRET_NAME` – name or ARN of the Bedrock API key secret.
 - `BEDROCK_TEMPERATURE`, `BEDROCK_NUM_CTX`, `BEDROCK_MAX_TOKENS`,
   `BEDROCK_TOP_P`, `BEDROCK_TOP_K`, `BEDROCK_MAX_TOKENS_TO_SAMPLE` – sampling
   settings applied to each Bedrock request.

--- a/services/llm-invocation/template.yaml
+++ b/services/llm-invocation/template.yaml
@@ -6,7 +6,7 @@ Parameters:
   BedrockOpenAIEndpoint:
     Type: String
     Default: ''
-  BedrockApiKey:
+  BedrockSecretName:
     Type: String
     Default: ''
   BedrockTemperature:
@@ -91,7 +91,7 @@ Resources:
       Environment:
         Variables:
           BEDROCK_OPENAI_ENDPOINTS: !Ref BedrockOpenAIEndpoint
-          BEDROCK_API_KEY: !Ref BedrockApiKey
+          BEDROCK_SECRET_NAME: !Ref BedrockSecretName
           BEDROCK_TEMPERATURE: !Ref BedrockTemperature
           BEDROCK_NUM_CTX: !Ref BedrockNumCtx
           BEDROCK_MAX_TOKENS: !Ref BedrockMaxTokens

--- a/services/llm-router/README.md
+++ b/services/llm-router/README.md
@@ -23,7 +23,7 @@ The routing logic is split into small modules which can also be reused outside t
 | Parameter | Environment variable | Description |
 |-----------|----------------------|-------------|
 | `BedrockOpenAIEndpoint` | `BEDROCK_OPENAI_ENDPOINTS` | Comma-separated Bedrock OpenAI endpoints |
-| `BedrockApiKey` | `BEDROCK_API_KEY` | API key when calling Bedrock |
+| `BedrockSecretName` | `BEDROCK_SECRET_NAME` | Name or ARN of the Bedrock API key secret |
 | `OllamaEndpoint` | `OLLAMA_ENDPOINTS` | URLs of Ollama services |
 | `OllamaDefaultModel` | `OLLAMA_DEFAULT_MODEL` | Default model when none supplied |
 | `PromptComplexityThreshold` | `PROMPT_COMPLEXITY_THRESHOLD` | Word threshold used by the heuristic router |

--- a/services/llm-router/template.yaml
+++ b/services/llm-router/template.yaml
@@ -6,7 +6,7 @@ Parameters:
   BedrockOpenAIEndpoint:
     Type: String
     Default: ''
-  BedrockApiKey:
+  BedrockSecretName:
     Type: String
     Default: ''
   OllamaEndpoint:
@@ -48,7 +48,7 @@ Resources:
       Environment:
         Variables:
           BEDROCK_OPENAI_ENDPOINTS: !Ref BedrockOpenAIEndpoint
-          BEDROCK_API_KEY: !Ref BedrockApiKey
+          BEDROCK_SECRET_NAME: !Ref BedrockSecretName
           OLLAMA_ENDPOINTS: !Ref OllamaEndpoint
           OLLAMA_DEFAULT_MODEL: !Ref OllamaDefaultModel
           PROMPT_COMPLEXITY_THRESHOLD: !Ref PromptComplexityThreshold

--- a/services/rag-ingestion/embed-lambda/app.py
+++ b/services/rag-ingestion/embed-lambda/app.py
@@ -13,6 +13,7 @@ from common_utils import configure_logger
 from typing import Any, Dict, List
 
 from common_utils.get_ssm import get_config
+from common_utils.get_secret import get_secret
 
 # Module Metadata
 __author__ = "Koushik Sinha"
@@ -76,7 +77,8 @@ def _cohere_embed(text: str) -> List[float]:
 
     import cohere  # type: ignore
 
-    api_key = get_config("COHERE_API_KEY", decrypt=True) or os.environ.get("COHERE_API_KEY")
+    secret = os.environ.get("COHERE_SECRET_NAME", "COHERE_API_KEY")
+    api_key = get_secret(secret)
     client = cohere.Client(api_key)
     resp = client.embed([text])
     return resp.embeddings[0]

--- a/services/rag-retrieval/README.md
+++ b/services/rag-retrieval/README.md
@@ -28,9 +28,10 @@ The retrieval logic calls the search Lambda defined by the `VECTOR_SEARCH_FUNCTI
 - `EMBED_MODEL` – default embedding provider (`sbert` by default).
 - `SBERT_MODEL` – SentenceTransformer model name or S3 path.
 - `OPENAI_EMBED_MODEL` – embedding model name for OpenAI.
-- `COHERE_API_KEY` – API key when using Cohere embeddings.
+ - `COHERE_SECRET_NAME` – name or ARN of the Cohere API key secret.
 - `CROSS_ENCODER_MODEL` – model name or S3 path for the cross-encoder.
 - `RERANK_PROVIDER` – rerank provider (`huggingface`, `cohere` or `nvidia`).
+- `NVIDIA_SECRET_NAME` – name or ARN of the NVIDIA API key secret.
 - `VECTOR_SEARCH_CANDIDATES` – number of candidates retrieved before re-ranking.
 
 Values can be stored in Parameter Store and loaded with the shared `get_config` helper.

--- a/services/rag-retrieval/rerank-lambda/app.py
+++ b/services/rag-retrieval/rerank-lambda/app.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Callable
 import json
 
 from common_utils.get_ssm import get_config
+from common_utils.get_secret import get_secret
 
 # Module Metadata
 __author__ = "Koushik Sinha"
@@ -50,9 +51,8 @@ def _cohere_rerank(query: str, docs: List[str]) -> List[float]:
 
     import cohere  # type: ignore
 
-    api_key = get_config("COHERE_API_KEY", decrypt=True) or os.environ.get(
-        "COHERE_API_KEY"
-    )
+    secret = os.environ.get("COHERE_SECRET_NAME", "COHERE_API_KEY")
+    api_key = get_secret(secret)
     client = cohere.Client(api_key)
     try:
         resp = client.rerank(query=query, documents=docs, top_n=len(docs))
@@ -68,7 +68,8 @@ def _nvidia_rerank(query: str, docs: List[str]) -> List[float]:
     import httpx  # type: ignore
 
     endpoint = os.environ.get("NVIDIA_RERANK_ENDPOINT")
-    api_key = os.environ.get("NVIDIA_API_KEY")
+    n_secret = os.environ.get("NVIDIA_SECRET_NAME", "NVIDIA_API_KEY")
+    api_key = get_secret(n_secret)
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
     payload = {"query": query, "documents": docs}
     try:

--- a/services/rag-retrieval/summarize-with-context-lambda/app.py
+++ b/services/rag-retrieval/summarize-with-context-lambda/app.py
@@ -16,6 +16,7 @@ import hashlib
 from typing import Any, Dict
 
 from common_utils.get_ssm import get_config
+from common_utils.get_secret import get_secret
 
 # Module Metadata
 __author__ = "Koushik Sinha"
@@ -84,7 +85,8 @@ def _cohere_embed(text: str) -> list[float]:
 
     import cohere  # type: ignore
 
-    api_key = get_config("COHERE_API_KEY", decrypt=True) or os.environ.get("COHERE_API_KEY")
+    secret = os.environ.get("COHERE_SECRET_NAME", "COHERE_API_KEY")
+    api_key = get_secret(secret)
     client = cohere.Client(api_key)
     resp = client.embed([text])
     return resp.embeddings[0]

--- a/services/rag-retrieval/template.yaml
+++ b/services/rag-retrieval/template.yaml
@@ -23,6 +23,12 @@ Parameters:
   VectorSearchCandidates:
     Type: String
     Default: '5'
+  CohereSecretName:
+    Type: String
+    Default: ''
+  NvidiaSecretName:
+    Type: String
+    Default: ''
 
 Globals:
   Function:
@@ -44,6 +50,7 @@ Resources:
           VECTOR_SEARCH_CANDIDATES: !Ref VectorSearchCandidates
           SUMMARY_ENDPOINT: !Ref SummaryEndpoint
           ROUTELLM_ENDPOINT: !Ref RouteLlmEndpoint
+          COHERE_SECRET_NAME: !Ref CohereSecretName
       Events:
         Api:
           Type: Api
@@ -90,6 +97,8 @@ Resources:
           TOP_K: !Ref VectorSearchCandidates
           CROSS_ENCODER_MODEL: ''
           RERANK_PROVIDER: ''
+          COHERE_SECRET_NAME: !Ref CohereSecretName
+          NVIDIA_SECRET_NAME: !Ref NvidiaSecretName
 
 Outputs:
   RerankFunctionArn:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,6 +275,19 @@ def chunking_layer_path():
     sys.path.insert(0, os.path.join(os.getcwd(), 'common/layers/chunking-layer/python'))
     yield
 
+
+@pytest.fixture(autouse=True)
+def common_utils_path():
+    import sys, os
+    sys.path.insert(0, os.path.join(os.getcwd(), 'common/layers/common-utils/python'))
+    import importlib, types
+    sec = importlib.import_module('common_utils.get_secret')
+    sec._SECRET_CACHE.clear()
+    sec._secrets_client = type('C', (), {'get_secret_value': lambda self, SecretId=None: {'SecretString': 'dummy'}})()
+    es_mod = importlib.import_module('common_utils.elasticsearch_client')
+    es_mod.Elasticsearch = lambda *a, **k: types.SimpleNamespace(index=lambda **kw: None, delete=lambda **kw: None, search=lambda **kw: {'hits': {'hits': []}}, indices=types.SimpleNamespace(create=lambda **kw: None, delete=lambda **kw: None))
+    yield
+
 @pytest.fixture
 def validate_schema():
     def _check(obj):


### PR DESCRIPTION
## Summary
- add `get_secret` helper for AWS Secrets Manager
- switch services to retrieve API keys with `get_secret`
- pass secret names in CloudFormation templates
- document secret-based configuration
- update tests for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c0fd0b80832f87de2ea3b203a7af