### PR TITLE
Add EFS path option for rerank model

### DIFF
--- a/services/rag-retrieval/README.md
+++ b/services/rag-retrieval/README.md
@@ -30,11 +30,34 @@ The retrieval logic calls the search Lambda defined by the `VECTOR_SEARCH_FUNCTI
 - `OPENAI_EMBED_MODEL` – embedding model name for OpenAI.
  - `COHERE_SECRET_NAME` – name or ARN of the Cohere API key secret.
 - `CROSS_ENCODER_MODEL` – model name or S3 path for the cross-encoder.
+- `CROSS_ENCODER_EFS_PATH` – local path to load the cross encoder from an
+  attached EFS volume.
 - `RERANK_PROVIDER` – rerank provider (`huggingface`, `cohere` or `nvidia`).
 - `NVIDIA_SECRET_NAME` – name or ARN of the NVIDIA API key secret.
 - `VECTOR_SEARCH_CANDIDATES` – number of candidates retrieved before re-ranking.
 
 Values can be stored in Parameter Store and loaded with the shared `get_config` helper.
+
+## Mounting an EFS access point
+
+To keep the cross encoder available between invocations, mount an EFS
+access point to the re-rank Lambda and point `CROSS_ENCODER_EFS_PATH`
+to the model on that file system.
+
+1. Create an EFS file system and access point.
+2. Add a `FileSystemConfigs` block to `RerankFunction` in
+   `template.yaml`:
+
+   ```yaml
+   RerankFunction:
+     Type: AWS::Serverless::Function
+     Properties:
+       FileSystemConfigs:
+         - Arn: arn:aws:elasticfilesystem:<region>:<account-id>:access-point/<ap-id>
+           LocalMountPath: /mnt/models
+   ```
+3. Copy the cross encoder to `/mnt/models` and set
+   `CROSS_ENCODER_EFS_PATH` accordingly.
 
 ## Deployment
 

--- a/services/rag-retrieval/rerank-lambda/app.py
+++ b/services/rag-retrieval/rerank-lambda/app.py
@@ -22,6 +22,10 @@ TOP_K = int(get_config("TOP_K") or os.environ.get("TOP_K", "5"))
 DEFAULT_MODEL = get_config("CROSS_ENCODER_MODEL") or os.environ.get(
     "CROSS_ENCODER_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2"
 )
+# Optional EFS path to load the cross encoder without downloading from S3
+EFS_MODEL_PATH = get_config("CROSS_ENCODER_EFS_PATH") or os.environ.get(
+    "CROSS_ENCODER_EFS_PATH"
+)
 # RERANK_PROVIDER selects the rerank provider (e.g. cohere, nvidia).
 DEFAULT_PROVIDER = (
     get_config("RERANK_PROVIDER") or os.environ.get("RERANK_PROVIDER", "huggingface")
@@ -88,7 +92,7 @@ def _load_model():
     global _CE_MODEL
     if _CE_MODEL is not None:
         return _CE_MODEL
-    model_path = DEFAULT_MODEL
+    model_path = EFS_MODEL_PATH or DEFAULT_MODEL
     try:
         if model_path.startswith("s3://"):
             import boto3

--- a/services/rag-retrieval/template.yaml
+++ b/services/rag-retrieval/template.yaml
@@ -96,6 +96,7 @@ Resources:
         Variables:
           TOP_K: !Ref VectorSearchCandidates
           CROSS_ENCODER_MODEL: ''
+          CROSS_ENCODER_EFS_PATH: ''
           RERANK_PROVIDER: ''
           COHERE_SECRET_NAME: !Ref CohereSecretName
           NVIDIA_SECRET_NAME: !Ref NvidiaSecretName


### PR DESCRIPTION
## Summary
- load the cross encoder from an optional `CROSS_ENCODER_EFS_PATH`
- document the variable and how to mount EFS for the Lambda
- expose the new variable in the SAM template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c4a59b94832f8687f73111af50cf