### PR TITLE
Remove legacy complexity routing function

### DIFF
--- a/services/llm-router/README.md
+++ b/services/llm-router/README.md
@@ -73,3 +73,8 @@ aws lambda invoke \
 The response includes a `backend` field indicating which service handled the request. You may set `backend` in the payload to force a specific destination. When omitted the router uses the heuristic strategy described above.
 
 Requests are now placed on the SQS queue configured by `INVOCATION_QUEUE_URL` so the invocation Lambda processes them asynchronously.
+
+The heuristic strategy is implemented by the `HeuristicRouter` module in the
+shared layer.  By default it chooses Bedrock once the prompt length exceeds
+`PROMPT_COMPLEXITY_THRESHOLD` words. Additional rules can be supplied via the
+`HEURISTIC_ROUTER_CONFIG` environment variable.

--- a/services/llm-router/router-lambda/app.py
+++ b/services/llm-router/router-lambda/app.py
@@ -81,23 +81,6 @@ def _sanitize_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     safe = re.sub(r"[<>\"']", "", safe)
     payload["prompt"] = safe
     return payload
-def _choose_backend(prompt: str) -> str:
-    """Return which backend to use based on prompt complexity."""
-    classifier_model = os.environ.get("CLASSIFIER_MODEL_ID") or os.environ.get("WEAK_MODEL_ID")
-    if classifier_model:
-        try:
-            result = invoke_classifier(boto3.client("lambda"), classifier_model, prompt)
-            if result == "complex":
-                return "bedrock"
-            if result == "simple":
-                return "ollama"
-        except Exception as exc:  # pragma: no cover - ML model failure
-            logger.exception("Classifier error: %s", exc)
-
-    complexity = len(prompt.split())
-    if complexity >= PROMPT_COMPLEXITY_THRESHOLD:
-        return "bedrock"
-    return "ollama"
 
 
 def lambda_handler(event: LlmRouterEvent, context: Any) -> LambdaResponse:

--- a/tests/test_router_lambda.py
+++ b/tests/test_router_lambda.py
@@ -19,18 +19,6 @@ def _make_fake_send(calls):
     return FakeSQS()
 
 
-def test_choose_backend(monkeypatch):
-    monkeypatch.setenv("PROMPT_COMPLEXITY_THRESHOLD", "3")
-    monkeypatch.setenv("CLASSIFIER_MODEL_ID", "x")
-    module = load_lambda("router_app", "services/llm-router/router-lambda/app.py")
-    monkeypatch.setattr(
-        module,
-        "invoke_classifier",
-        lambda client, model, prompt: "complex" if len(prompt.split()) > 3 else "simple",
-    )
-    assert module._choose_backend("a b") == "ollama"
-    assert module._choose_backend("a b c d") == "bedrock"
-
 
 def test_lambda_handler(monkeypatch):
     monkeypatch.setenv("INVOCATION_QUEUE_URL", "url")


### PR DESCRIPTION
## Summary
- drop unused `_choose_backend` from router lambda
- remove obsolete tests for `_choose_backend`
- document heuristic router usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867cb3852b0832f9eaea4f2f2df6be1