### PR TITLE
Use get_config for Lambda settings

### DIFF
--- a/common/layers/common-utils/python/common_utils/elasticsearch_client.py
+++ b/common/layers/common-utils/python/common_utils/elasticsearch_client.py
@@ -11,6 +11,7 @@ import os
 from typing import Any, Iterable, List, Optional
 
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 logger = configure_logger(__name__)
 
@@ -30,8 +31,16 @@ class ElasticsearchClient:
         ``ELASTICSEARCH_INDEX_PREFIX`` environment variables respectively.
         """
 
-        self.url = url or os.environ.get("ELASTICSEARCH_URL", "http://localhost:9200")
-        self.index_prefix = index_prefix or os.environ.get("ELASTICSEARCH_INDEX_PREFIX", "docs")
+        self.url = (
+            url
+            or get_config("ELASTICSEARCH_URL")
+            or os.environ.get("ELASTICSEARCH_URL", "http://localhost:9200")
+        )
+        self.index_prefix = (
+            index_prefix
+            or get_config("ELASTICSEARCH_INDEX_PREFIX")
+            or os.environ.get("ELASTICSEARCH_INDEX_PREFIX", "docs")
+        )
 
         if Elasticsearch is None:  # pragma: no cover - imported module missing
             raise ImportError("elasticsearch package is required to use ElasticsearchClient")

--- a/common/layers/common-utils/python/common_utils/get_ssm.py
+++ b/common/layers/common-utils/python/common_utils/get_ssm.py
@@ -63,6 +63,9 @@ def get_config(name: str, bucket: str | None = None, key: str | None = None,
         except Exception as exc:  # pragma: no cover - fallback to SSM
             logger.warning("Tag lookup failed for %s/%s: %s", bucket, key, exc)
 
-    param_name = f"{get_environment_prefix()}/{name}"
-    return get_values_from_ssm(param_name, decrypt)
+    try:
+        param_name = f"{get_environment_prefix()}/{name}"
+        return get_values_from_ssm(param_name, decrypt)
+    except Exception:
+        return None
 

--- a/common/layers/common-utils/python/common_utils/milvus_client.py
+++ b/common/layers/common-utils/python/common_utils/milvus_client.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Any, Iterable, List, Optional
 
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 logger = configure_logger(__name__)
 
@@ -75,10 +76,14 @@ class MilvusClient:
         - ``metric_type`` from ``MILVUS_METRIC_TYPE`` or ``index_params``
         """
 
-        self.host = host or os.environ.get("MILVUS_HOST", "localhost")
-        self.port = int(port or os.environ.get("MILVUS_PORT", "19530"))
-        self.collection_name = collection_name or os.environ.get(
-            "MILVUS_COLLECTION", "docs"
+        self.host = host or get_config("MILVUS_HOST") or os.environ.get("MILVUS_HOST", "localhost")
+        self.port = int(
+            port or get_config("MILVUS_PORT") or os.environ.get("MILVUS_PORT", "19530")
+        )
+        self.collection_name = (
+            collection_name
+            or get_config("MILVUS_COLLECTION")
+            or os.environ.get("MILVUS_COLLECTION", "docs")
         )
 
         if Collection is None or connections is None:  # pragma: no cover
@@ -86,7 +91,7 @@ class MilvusClient:
 
         # Optional tuning parameters read from env if not provided
         if index_params is None:
-            params = os.environ.get("MILVUS_INDEX_PARAMS")
+            params = get_config("MILVUS_INDEX_PARAMS") or os.environ.get("MILVUS_INDEX_PARAMS")
             if params:
                 try:
                     index_params = json.loads(params)
@@ -95,11 +100,11 @@ class MilvusClient:
         self.index_params = index_params
 
         if metric_type is None:
-            metric_type = os.environ.get("MILVUS_METRIC_TYPE")
+            metric_type = get_config("MILVUS_METRIC_TYPE") or os.environ.get("MILVUS_METRIC_TYPE")
         self.metric_type = metric_type or (index_params or {}).get("metric_type", "L2")
 
         if search_params is None:
-            params = os.environ.get("MILVUS_SEARCH_PARAMS")
+            params = get_config("MILVUS_SEARCH_PARAMS") or os.environ.get("MILVUS_SEARCH_PARAMS")
             if params:
                 try:
                     search_params = json.loads(params)

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-Each service loads its configuration from Parameter Store or the Lambda environment. The table below summarises the most common variables.
+Each service loads its configuration from Parameter Store or the Lambda environment. Values are retrieved using the ``get_config`` helper so every variable may be supplied via SSM under the environment prefix. The table below summarises the most common variables.
 
 ### Core services
 

--- a/services/entity-tokenization/tokenize-entity-lambda/app.py
+++ b/services/entity-tokenization/tokenize-entity-lambda/app.py
@@ -9,12 +9,13 @@ from typing import Any, Dict
 
 import boto3
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 logger = configure_logger(__name__)
 
-TABLE_NAME = os.environ.get("TOKEN_TABLE")
-PREFIX = os.environ.get("TOKEN_PREFIX", "ent_")
-SALT = os.environ.get("TOKEN_SALT", "")
+TABLE_NAME = get_config("TOKEN_TABLE") or os.environ.get("TOKEN_TABLE")
+PREFIX = get_config("TOKEN_PREFIX") or os.environ.get("TOKEN_PREFIX", "ent_")
+SALT = get_config("TOKEN_SALT") or os.environ.get("TOKEN_SALT", "")
 
 _dynamo = boto3.resource("dynamodb")
 _table = _dynamo.Table(TABLE_NAME)

--- a/services/knowledge-base/ingest-lambda/app.py
+++ b/services/knowledge-base/ingest-lambda/app.py
@@ -6,6 +6,7 @@ import json
 import os
 import logging
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 import boto3
 from botocore.exceptions import ClientError
 
@@ -16,12 +17,15 @@ __modified_by__ = "Koushik Sinha"
 
 logger = configure_logger(__name__)
 
-STATE_MACHINE_ARN = os.environ.get("STATE_MACHINE_ARN")
+STATE_MACHINE_ARN = get_config("STATE_MACHINE_ARN") or os.environ.get(
+    "STATE_MACHINE_ARN"
+)
 if not STATE_MACHINE_ARN:
     raise RuntimeError("STATE_MACHINE_ARN not configured")
 
-FILE_INGESTION_STATE_MACHINE_ARN = os.environ.get(
-    "FILE_INGESTION_STATE_MACHINE_ARN"
+FILE_INGESTION_STATE_MACHINE_ARN = (
+    get_config("FILE_INGESTION_STATE_MACHINE_ARN")
+    or os.environ.get("FILE_INGESTION_STATE_MACHINE_ARN")
 )
 if not FILE_INGESTION_STATE_MACHINE_ARN:
     raise RuntimeError("FILE_INGESTION_STATE_MACHINE_ARN not configured")

--- a/services/knowledge-base/query-lambda/app.py
+++ b/services/knowledge-base/query-lambda/app.py
@@ -10,6 +10,7 @@ import json
 import os
 import logging
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 import boto3
 from botocore.exceptions import ClientError
 
@@ -32,7 +33,7 @@ def lambda_handler(event: dict, context: object) -> dict:
     Returns whether the request was queued successfully.
     """
 
-    queue_url = os.environ.get("SUMMARY_QUEUE_URL")
+    queue_url = get_config("SUMMARY_QUEUE_URL") or os.environ.get("SUMMARY_QUEUE_URL")
     if not queue_url:
         logger.error("SUMMARY_QUEUE_URL not configured")
         return {"error": "SUMMARY_QUEUE_URL not configured"}

--- a/services/llm-router/router-lambda/app.py
+++ b/services/llm-router/router-lambda/app.py
@@ -30,17 +30,20 @@ __modified_by__ = "Koushik Sinha"
 
 logger = configure_logger(__name__)
 
-INVOCATION_QUEUE_URL = os.environ.get("INVOCATION_QUEUE_URL")
+INVOCATION_QUEUE_URL = get_config("INVOCATION_QUEUE_URL") or os.environ.get(
+    "INVOCATION_QUEUE_URL"
+)
 sqs_client = boto3.client("sqs")
 
 DEFAULT_PROMPT_COMPLEXITY_THRESHOLD = 20
 PROMPT_COMPLEXITY_THRESHOLD = int(
-    os.environ.get("PROMPT_COMPLEXITY_THRESHOLD", str(DEFAULT_PROMPT_COMPLEXITY_THRESHOLD))
+    get_config("PROMPT_COMPLEXITY_THRESHOLD")
+    or os.environ.get("PROMPT_COMPLEXITY_THRESHOLD", str(DEFAULT_PROMPT_COMPLEXITY_THRESHOLD))
 )
 
 # allowlist of permitted backends
 DEFAULT_ALLOWED_BACKENDS = {"bedrock", "ollama"}
-_raw_backends = os.environ.get("ALLOWED_BACKENDS")
+_raw_backends = get_config("ALLOWED_BACKENDS") or os.environ.get("ALLOWED_BACKENDS")
 if not _raw_backends:
     try:  # pragma: no cover - SSM may be unavailable in tests
         _raw_backends = get_config("ALLOWED_BACKENDS")
@@ -52,7 +55,7 @@ if _raw_backends:
 else:
     ALLOWED_BACKENDS = DEFAULT_ALLOWED_BACKENDS
 # maximum prompt length accepted by the router
-MAX_PROMPT_LENGTH = int(os.environ.get("MAX_PROMPT_LENGTH", "4096"))
+MAX_PROMPT_LENGTH = int(get_config("MAX_PROMPT_LENGTH") or os.environ.get("MAX_PROMPT_LENGTH", "4096"))
 
 
 def _sanitize_payload(payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/services/prompt-engine/prompt-engine-lambda/app.py
+++ b/services/prompt-engine/prompt-engine-lambda/app.py
@@ -14,6 +14,7 @@ from typing import Any, Dict
 import boto3
 from boto3.dynamodb.conditions import Attr
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 # Module Metadata
 __author__ = "Koushik Sinha"
@@ -22,8 +23,10 @@ __modified_by__ = "Koushik Sinha"
 
 logger = configure_logger(__name__)
 
-PROMPT_LIBRARY_TABLE = os.environ.get("PROMPT_LIBRARY_TABLE")
-ROUTER_ENDPOINT = os.environ.get("ROUTER_ENDPOINT")
+PROMPT_LIBRARY_TABLE = get_config("PROMPT_LIBRARY_TABLE") or os.environ.get(
+    "PROMPT_LIBRARY_TABLE"
+)
+ROUTER_ENDPOINT = get_config("ROUTER_ENDPOINT") or os.environ.get("ROUTER_ENDPOINT")
 
 _dynamo = boto3.resource("dynamodb")
 _table = _dynamo.Table(PROMPT_LIBRARY_TABLE)

--- a/services/rag-ingestion/embed-lambda/app.py
+++ b/services/rag-ingestion/embed-lambda/app.py
@@ -77,7 +77,9 @@ def _cohere_embed(text: str) -> List[float]:
 
     import cohere  # type: ignore
 
-    secret = os.environ.get("COHERE_SECRET_NAME", "COHERE_API_KEY")
+    secret = get_config("COHERE_SECRET_NAME") or os.environ.get(
+        "COHERE_SECRET_NAME", "COHERE_API_KEY"
+    )
     api_key = get_secret(secret)
     client = cohere.Client(api_key)
     resp = client.embed([text])

--- a/services/rag-retrieval/extract-entities-lambda/app.py
+++ b/services/rag-retrieval/extract-entities-lambda/app.py
@@ -24,7 +24,9 @@ __modified_by__ = "Koushik Sinha"
 
 logger = configure_logger(__name__)
 
-RERAISE_ERRORS = os.environ.get("RERAISE_ERRORS", "false").lower() == "true"
+RERAISE_ERRORS = (
+    get_config("RERAISE_ERRORS") or os.environ.get("RERAISE_ERRORS", "false")
+).lower() == "true"
 
 LAMBDA_FUNCTION = get_config("VECTOR_SEARCH_FUNCTION") or os.environ.get("VECTOR_SEARCH_FUNCTION")
 ENTITIES_ENDPOINT = get_config("ENTITIES_ENDPOINT") or os.environ.get("ENTITIES_ENDPOINT")

--- a/services/rag-retrieval/rerank-lambda/app.py
+++ b/services/rag-retrieval/rerank-lambda/app.py
@@ -55,7 +55,9 @@ def _cohere_rerank(query: str, docs: List[str]) -> List[float]:
 
     import cohere  # type: ignore
 
-    secret = os.environ.get("COHERE_SECRET_NAME", "COHERE_API_KEY")
+    secret = get_config("COHERE_SECRET_NAME") or os.environ.get(
+        "COHERE_SECRET_NAME", "COHERE_API_KEY"
+    )
     api_key = get_secret(secret)
     client = cohere.Client(api_key)
     try:
@@ -71,8 +73,12 @@ def _nvidia_rerank(query: str, docs: List[str]) -> List[float]:
 
     import httpx  # type: ignore
 
-    endpoint = os.environ.get("NVIDIA_RERANK_ENDPOINT")
-    n_secret = os.environ.get("NVIDIA_SECRET_NAME", "NVIDIA_API_KEY")
+    endpoint = get_config("NVIDIA_RERANK_ENDPOINT") or os.environ.get(
+        "NVIDIA_RERANK_ENDPOINT"
+    )
+    n_secret = get_config("NVIDIA_SECRET_NAME") or os.environ.get(
+        "NVIDIA_SECRET_NAME", "NVIDIA_API_KEY"
+    )
     api_key = get_secret(n_secret)
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
     payload = {"query": query, "documents": docs}

--- a/services/rag-retrieval/summarize-with-context-lambda/app.py
+++ b/services/rag-retrieval/summarize-with-context-lambda/app.py
@@ -85,7 +85,9 @@ def _cohere_embed(text: str) -> list[float]:
 
     import cohere  # type: ignore
 
-    secret = os.environ.get("COHERE_SECRET_NAME", "COHERE_API_KEY")
+    secret = get_config("COHERE_SECRET_NAME") or os.environ.get(
+        "COHERE_SECRET_NAME", "COHERE_API_KEY"
+    )
     api_key = get_secret(secret)
     client = cohere.Client(api_key)
     resp = client.embed([text])

--- a/services/sensitive-info-detection/detect-sensitive-info-lambda/app.py
+++ b/services/sensitive-info-detection/detect-sensitive-info-lambda/app.py
@@ -22,6 +22,7 @@ import re
 from typing import Any, Dict, List, Tuple
 
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 # ─── Logging Configuration ────────────────────────────────────────────────────
 logger = configure_logger(__name__)
@@ -43,12 +44,16 @@ def _load_model() -> Tuple[str, Any] | None:
     if _MODEL is not None:
         return _MODEL
 
-    library = os.environ.get("NER_LIBRARY", "spacy").lower()
+    library = (
+        get_config("NER_LIBRARY") or os.environ.get("NER_LIBRARY", "spacy")
+    ).lower()
     if library == "spacy":
         try:  # pragma: no cover - optional dependency
             import spacy  # type: ignore
 
-            model_name = os.environ.get("SPACY_MODEL", "en_core_web_sm")
+            model_name = get_config("SPACY_MODEL") or os.environ.get(
+                "SPACY_MODEL", "en_core_web_sm"
+            )
             _MODEL = ("spacy", spacy.load(model_name))
         except Exception as exc:  # pragma: no cover - runtime safety
             logger.exception("Failed to load spaCy model: %s", exc)
@@ -57,7 +62,9 @@ def _load_model() -> Tuple[str, Any] | None:
         try:  # pragma: no cover - optional dependency
             from transformers import pipeline  # type: ignore
 
-            model_name = os.environ.get("HF_MODEL", "dslim/bert-base-NER")
+            model_name = get_config("HF_MODEL") or os.environ.get(
+                "HF_MODEL", "dslim/bert-base-NER"
+            )
             _MODEL = (
                 "hf",
                 pipeline(
@@ -79,13 +86,18 @@ def _load_medical_model() -> Tuple[str, Any] | None:
     if _MEDICAL_MODEL is not None:
         return _MEDICAL_MODEL
 
-    library = os.environ.get("NER_LIBRARY", "spacy").lower()
+    library = (
+        get_config("NER_LIBRARY") or os.environ.get("NER_LIBRARY", "spacy")
+    ).lower()
     if library == "spacy":
         try:  # pragma: no cover - optional dependency
             import spacy  # type: ignore
 
-            model_name = os.environ.get(
-                "MEDICAL_MODEL", os.environ.get("SPACY_MODEL", "en_core_web_sm")
+            model_name = (
+                get_config("MEDICAL_MODEL")
+                or os.environ.get("MEDICAL_MODEL")
+                or get_config("SPACY_MODEL")
+                or os.environ.get("SPACY_MODEL", "en_core_web_sm")
             )
             _MEDICAL_MODEL = ("spacy", spacy.load(model_name))
         except Exception as exc:  # pragma: no cover - runtime safety
@@ -95,8 +107,11 @@ def _load_medical_model() -> Tuple[str, Any] | None:
         try:  # pragma: no cover - optional dependency
             from transformers import pipeline  # type: ignore
 
-            model_name = os.environ.get(
-                "MEDICAL_MODEL", os.environ.get("HF_MODEL", "dslim/bert-base-NER")
+            model_name = (
+                get_config("MEDICAL_MODEL")
+                or os.environ.get("MEDICAL_MODEL")
+                or get_config("HF_MODEL")
+                or os.environ.get("HF_MODEL", "dslim/bert-base-NER")
             )
             _MEDICAL_MODEL = (
                 "hf",
@@ -119,13 +134,18 @@ def _load_legal_model() -> Tuple[str, Any] | None:
     if _LEGAL_MODEL is not None:
         return _LEGAL_MODEL
 
-    library = os.environ.get("NER_LIBRARY", "spacy").lower()
+    library = (
+        get_config("NER_LIBRARY") or os.environ.get("NER_LIBRARY", "spacy")
+    ).lower()
     if library == "spacy":
         try:  # pragma: no cover - optional dependency
             import spacy  # type: ignore
 
-            model_name = os.environ.get(
-                "LEGAL_MODEL", os.environ.get("SPACY_MODEL", "en_core_web_sm")
+            model_name = (
+                get_config("LEGAL_MODEL")
+                or os.environ.get("LEGAL_MODEL")
+                or get_config("SPACY_MODEL")
+                or os.environ.get("SPACY_MODEL", "en_core_web_sm")
             )
             _LEGAL_MODEL = ("spacy", spacy.load(model_name))
         except Exception as exc:  # pragma: no cover - runtime safety
@@ -135,8 +155,11 @@ def _load_legal_model() -> Tuple[str, Any] | None:
         try:  # pragma: no cover - optional dependency
             from transformers import pipeline  # type: ignore
 
-            model_name = os.environ.get(
-                "LEGAL_MODEL", os.environ.get("HF_MODEL", "dslim/bert-base-NER")
+            model_name = (
+                get_config("LEGAL_MODEL")
+                or os.environ.get("LEGAL_MODEL")
+                or get_config("HF_MODEL")
+                or os.environ.get("HF_MODEL", "dslim/bert-base-NER")
             )
             _LEGAL_MODEL = (
                 "hf",
@@ -172,14 +195,14 @@ def _load_regex_patterns() -> None:
     _REGEX_PATTERNS = dict(_DEFAULT_REGEX_PATTERNS)
     _LEGAL_REGEX_PATTERNS = dict(_DEFAULT_LEGAL_REGEX_PATTERNS)
 
-    env_patterns = os.environ.get("REGEX_PATTERNS")
+    env_patterns = get_config("REGEX_PATTERNS") or os.environ.get("REGEX_PATTERNS")
     if env_patterns:
         try:
             _REGEX_PATTERNS.update(json.loads(env_patterns))
         except Exception as exc:  # pragma: no cover - runtime safety
             logger.exception("Invalid REGEX_PATTERNS: %s", exc)
 
-    env_legal = os.environ.get("LEGAL_REGEX_PATTERNS")
+    env_legal = get_config("LEGAL_REGEX_PATTERNS") or os.environ.get("LEGAL_REGEX_PATTERNS")
     if env_legal:
         try:
             _LEGAL_REGEX_PATTERNS.update(json.loads(env_legal))

--- a/services/summarization/load-prompts-lambda/app.py
+++ b/services/summarization/load-prompts-lambda/app.py
@@ -6,12 +6,17 @@ from typing import Any, Dict
 
 import httpx
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 logger = configure_logger(__name__)
 
-PROMPT_ENGINE_ENDPOINT = os.environ.get("PROMPT_ENGINE_ENDPOINT")
+PROMPT_ENGINE_ENDPOINT = get_config("PROMPT_ENGINE_ENDPOINT") or os.environ.get(
+    "PROMPT_ENGINE_ENDPOINT"
+)
 
-SYSTEM_WORKFLOW_ID = os.environ.get("SYSTEM_WORKFLOW_ID", "sys")
+SYSTEM_WORKFLOW_ID = (
+    get_config("SYSTEM_WORKFLOW_ID") or os.environ.get("SYSTEM_WORKFLOW_ID", "sys")
+)
 
 
 def _process_event(event: Dict[str, Any]) -> Dict[str, Any]:

--- a/services/summarization/summarize-worker-lambda/app.py
+++ b/services/summarization/summarize-worker-lambda/app.py
@@ -8,14 +8,19 @@ from typing import Any, Dict
 
 import boto3
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 logger = configure_logger(__name__)
 
 lambda_client = boto3.client("lambda")
 sf_client = boto3.client("stepfunctions")
 
-SUMMARY_FUNCTION_ARN = os.environ.get("RAG_SUMMARY_FUNCTION_ARN")
-PROMPT_ENGINE_ENDPOINT = os.environ.get("PROMPT_ENGINE_ENDPOINT")
+SUMMARY_FUNCTION_ARN = (
+    get_config("RAG_SUMMARY_FUNCTION_ARN") or os.environ.get("RAG_SUMMARY_FUNCTION_ARN")
+)
+PROMPT_ENGINE_ENDPOINT = get_config("PROMPT_ENGINE_ENDPOINT") or os.environ.get(
+    "PROMPT_ENGINE_ENDPOINT"
+)
 
 
 def _process_record(record: Dict[str, Any]) -> None:

--- a/services/text-anonymization/anonymize-text-lambda/app.py
+++ b/services/text-anonymization/anonymize-text-lambda/app.py
@@ -8,12 +8,13 @@ from typing import Any, Dict, List, Tuple
 import httpx
 from faker import Faker
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 logger = configure_logger(__name__)
 
-MODE = os.environ.get("ANON_MODE", "mask").lower()
-TOKEN_API_URL = os.environ.get("TOKEN_API_URL", "")
-TIMEOUT = float(os.environ.get("ANON_TIMEOUT", "3"))
+MODE = (get_config("ANON_MODE") or os.environ.get("ANON_MODE", "mask")).lower()
+TOKEN_API_URL = get_config("TOKEN_API_URL") or os.environ.get("TOKEN_API_URL", "")
+TIMEOUT = float(get_config("ANON_TIMEOUT") or os.environ.get("ANON_TIMEOUT", "3"))
 
 _fake = Faker()
 


### PR DESCRIPTION
## Summary
- pull parameters from SSM using `get_config` across services
- handle missing SSM values gracefully
- document that variables can be supplied via SSM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d3d86f20832fa0fc39eaf155fd83