### PR TITLE
Refine exception handling

### DIFF
--- a/common/layers/chunking-layer/python/chunking/advanced_chunkers.py
+++ b/common/layers/chunking-layer/python/chunking/advanced_chunkers.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 import nbformat
 from pygments.lexers import guess_lexer_for_filename
+from pygments.util import ClassNotFound
 from tree_sitter import Language, Parser
 import tiktoken
 
@@ -74,7 +75,7 @@ class CodeFileChunker(TextFileChunker):
                 part = text[node.start_byte : node.end_byte]
                 chunks.extend(super().chunk(part))
             return chunks or super().chunk(text)
-        except Exception:
+        except (OSError, RuntimeError, ValueError):
             return super().chunk(text)
 
 
@@ -121,7 +122,7 @@ class UniversalFileChunker:
                 try:
                     lexer = guess_lexer_for_filename(file_name, text)
                     language = lexer.name.lower()
-                except Exception:
+                except ClassNotFound:
                     pass
             return CodeFileChunker(self.max_tokens, self.overlap, language).chunk(text)
         return self.text_chunker.chunk(text)

--- a/common/layers/common-utils/python/common_utils/elasticsearch_client.py
+++ b/common/layers/common-utils/python/common_utils/elasticsearch_client.py
@@ -17,7 +17,7 @@ logger = configure_logger(__name__)
 
 try:  # pragma: no cover - optional dependency
     from elasticsearch import Elasticsearch
-except Exception:  # pragma: no cover - allow import without elasticsearch
+except ImportError:  # pragma: no cover - allow import without elasticsearch
     Elasticsearch = None  # type: ignore
 
 

--- a/common/layers/common-utils/python/common_utils/entity_extraction.py
+++ b/common/layers/common-utils/python/common_utils/entity_extraction.py
@@ -36,7 +36,7 @@ def _load_spacy():
 
         model = get_config("SPACY_MODEL") or os.environ.get("SPACY_MODEL", "en_core_web_sm")
         _NLP = spacy.load(model)
-    except Exception:
+    except (ImportError, OSError):
         _NLP = None
     return _NLP
 

--- a/common/layers/common-utils/python/common_utils/get_secret.py
+++ b/common/layers/common-utils/python/common_utils/get_secret.py
@@ -6,6 +6,10 @@ import os
 from typing import Optional
 
 import boto3
+try:  # pragma: no cover - optional dependency
+    from botocore.exceptions import BotoCoreError, ClientError
+except Exception:  # pragma: no cover - allow import without botocore
+    BotoCoreError = ClientError = Exception  # type: ignore
 
 from common_utils import configure_logger
 
@@ -35,6 +39,6 @@ def get_secret(name: str) -> Optional[str]:
         _SECRET_CACHE[secret_name] = value
         logger.info("Loaded secret %s", secret_name)
         return value
-    except Exception as exc:
+    except (BotoCoreError, ClientError) as exc:
         logger.error("Error retrieving secret %s: %s", secret_name, exc)
         raise

--- a/common/layers/common-utils/python/common_utils/milvus_client.py
+++ b/common/layers/common-utils/python/common_utils/milvus_client.py
@@ -19,9 +19,11 @@ logger = configure_logger(__name__)
 
 try:  # pragma: no cover - optional dependency
     from pymilvus import Collection, connections
+    from pymilvus.exceptions import MilvusException
 except Exception:  # pragma: no cover - allow import without pymilvus
     Collection = None  # type: ignore
     connections = None  # type: ignore
+    MilvusException = Exception  # type: ignore
 
 
 @dataclass
@@ -119,7 +121,7 @@ class MilvusClient:
                 self.collection.create_index(
                     "embedding", self.index_params, index_name="embedding_idx"
                 )
-            except Exception:
+            except MilvusException:
                 # index may already exist
                 pass
 
@@ -219,7 +221,7 @@ class MilvusClient:
                 self.collection.create_index(
                     "embedding", self.index_params, index_name="embedding_idx"
                 )
-            except Exception:
+            except MilvusException:
                 pass
 
     def drop_collection(self) -> None:

--- a/common/layers/router-layer/python/heuristic_router.py
+++ b/common/layers/router-layer/python/heuristic_router.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, List
 
 import boto3
+try:  # pragma: no cover - optional dependency
+    from langdetect.lang_detect_exception import LangDetectException
+except Exception:  # pragma: no cover - allow import without langdetect
+    LangDetectException = Exception  # type: ignore
 from generative_router import invoke_bedrock_model
 from common_utils.get_ssm import get_config
 
@@ -196,7 +200,7 @@ class HeuristicRouter:
         except KeyError as e:
             trace_log.append(f"  - ERROR in language rule: {e}.")
             return None
-        except Exception as e:
+        except LangDetectException as e:
             trace_log.append(f"  - ERROR: Language detection failed: {e}.")
             return None
 
@@ -238,7 +242,7 @@ class HeuristicRouter:
                 return None
 
             return final_model
-        except (KeyError, json.JSONDecodeError, Exception) as e:
+        except (KeyError, json.JSONDecodeError, ValueError) as e:
             trace_log.append(f"  - ERROR in llm_classifier rule: {e}.")
             return None
 


### PR DESCRIPTION
## Summary
- refine spaCy load fallback in entity_extraction
- narrow elasticsearch optional import error
- handle boto and langdetect absence gracefully
- specify errors for secret and SSM helpers
- tighten Milvus index error handling
- improve chunking exception filtering
- use specific HTTP and boto exceptions in LLM backends

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867da70bfc4832f89d431c3b7b7e7d0