### PR TITLE
Add reusable NER model loader

### DIFF
--- a/common/layers/common-utils/python/common_utils/__init__.py
+++ b/common/layers/common-utils/python/common_utils/__init__.py
@@ -15,6 +15,7 @@ from .milvus_client import MilvusClient, VectorItem, SearchResult, GetResult
 from .elasticsearch_client import ElasticsearchClient
 from .entity_extraction import extract_entities
 from .lambda_response import lambda_response
+from .ner_models import load_ner_model
 
 __all__ = [
     "get_values_from_ssm",
@@ -30,4 +31,5 @@ __all__ = [
     "extract_entities",
     "configure_logger",
     "lambda_response",
+    "load_ner_model",
 ]

--- a/common/layers/common-utils/python/common_utils/ner_models.py
+++ b/common/layers/common-utils/python/common_utils/ner_models.py
@@ -1,0 +1,57 @@
+"""Helpers for loading spaCy or HuggingFace NER models."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Tuple
+
+from common_utils import configure_logger
+from common_utils.get_ssm import get_config
+
+logger = configure_logger(__name__)
+
+# Cache keyed by (spacy_env, hf_env)
+_MODEL_CACHE: dict[tuple[str, str], Tuple[str, Any] | None] = {}
+
+
+def load_ner_model(spacy_env: str, hf_env: str, default: str = "en_core_web_sm") -> Tuple[str, Any] | None:
+    """Load and cache an NER model specified by environment variables."""
+
+    key = (spacy_env, hf_env)
+    if key in _MODEL_CACHE:
+        return _MODEL_CACHE[key]
+
+    library = (get_config("NER_LIBRARY") or os.environ.get("NER_LIBRARY", "spacy")).lower()
+    if library == "spacy":
+        try:  # pragma: no cover - optional dependency
+            import spacy  # type: ignore
+
+            model_name = (
+                get_config(spacy_env)
+                or os.environ.get(spacy_env)
+                or get_config("SPACY_MODEL")
+                or os.environ.get("SPACY_MODEL", default)
+            )
+            _MODEL_CACHE[key] = ("spacy", spacy.load(model_name))
+        except Exception as exc:  # pragma: no cover - runtime safety
+            logger.exception("Failed to load spaCy model: %s", exc)
+            _MODEL_CACHE[key] = None
+    else:
+        try:  # pragma: no cover - optional dependency
+            from transformers import pipeline  # type: ignore
+
+            model_name = (
+                get_config(hf_env)
+                or os.environ.get(hf_env)
+                or get_config("HF_MODEL")
+                or os.environ.get("HF_MODEL", "dslim/bert-base-NER")
+            )
+            _MODEL_CACHE[key] = (
+                "hf",
+                pipeline("ner", model=model_name, aggregation_strategy="simple"),
+            )
+        except Exception as exc:  # pragma: no cover - runtime safety
+            logger.exception("Failed to load HuggingFace model: %s", exc)
+            _MODEL_CACHE[key] = None
+
+    return _MODEL_CACHE[key]

--- a/services/sensitive-info-detection/detect-sensitive-info-lambda/app.py
+++ b/services/sensitive-info-detection/detect-sensitive-info-lambda/app.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Tuple
 
 from common_utils import configure_logger
 from common_utils.get_ssm import get_config
+from common_utils.ner_models import load_ner_model
 
 # ─── Logging Configuration ────────────────────────────────────────────────────
 logger = configure_logger(__name__)
@@ -38,140 +39,29 @@ _LEGAL_MODEL: Tuple[str, Any] | None = None
 
 
 def _load_model() -> Tuple[str, Any] | None:
-    """Load either a spaCy or HuggingFace NER model based on env vars."""
+    """Return the default NER model."""
 
     global _MODEL
-    if _MODEL is not None:
-        return _MODEL
-
-    library = (
-        get_config("NER_LIBRARY") or os.environ.get("NER_LIBRARY", "spacy")
-    ).lower()
-    if library == "spacy":
-        try:  # pragma: no cover - optional dependency
-            import spacy  # type: ignore
-
-            model_name = get_config("SPACY_MODEL") or os.environ.get(
-                "SPACY_MODEL", "en_core_web_sm"
-            )
-            _MODEL = ("spacy", spacy.load(model_name))
-        except Exception as exc:  # pragma: no cover - runtime safety
-            logger.exception("Failed to load spaCy model: %s", exc)
-            _MODEL = None
-    else:
-        try:  # pragma: no cover - optional dependency
-            from transformers import pipeline  # type: ignore
-
-            model_name = get_config("HF_MODEL") or os.environ.get(
-                "HF_MODEL", "dslim/bert-base-NER"
-            )
-            _MODEL = (
-                "hf",
-                pipeline(
-                    "ner",
-                    model=model_name,
-                    aggregation_strategy="simple",
-                ),
-            )
-        except Exception as exc:  # pragma: no cover - runtime safety
-            logger.exception("Failed to load HuggingFace model: %s", exc)
-            _MODEL = None
+    if _MODEL is None:
+        _MODEL = load_ner_model("SPACY_MODEL", "HF_MODEL")
     return _MODEL
 
 
 def _load_medical_model() -> Tuple[str, Any] | None:
-    """Load a PHI-specific model based on environment variables."""
+    """Return the NER model for the Medical domain."""
 
     global _MEDICAL_MODEL
-    if _MEDICAL_MODEL is not None:
-        return _MEDICAL_MODEL
-
-    library = (
-        get_config("NER_LIBRARY") or os.environ.get("NER_LIBRARY", "spacy")
-    ).lower()
-    if library == "spacy":
-        try:  # pragma: no cover - optional dependency
-            import spacy  # type: ignore
-
-            model_name = (
-                get_config("MEDICAL_MODEL")
-                or os.environ.get("MEDICAL_MODEL")
-                or get_config("SPACY_MODEL")
-                or os.environ.get("SPACY_MODEL", "en_core_web_sm")
-            )
-            _MEDICAL_MODEL = ("spacy", spacy.load(model_name))
-        except Exception as exc:  # pragma: no cover - runtime safety
-            logger.exception("Failed to load medical spaCy model: %s", exc)
-            _MEDICAL_MODEL = None
-    else:
-        try:  # pragma: no cover - optional dependency
-            from transformers import pipeline  # type: ignore
-
-            model_name = (
-                get_config("MEDICAL_MODEL")
-                or os.environ.get("MEDICAL_MODEL")
-                or get_config("HF_MODEL")
-                or os.environ.get("HF_MODEL", "dslim/bert-base-NER")
-            )
-            _MEDICAL_MODEL = (
-                "hf",
-                pipeline(
-                    "ner",
-                    model=model_name,
-                    aggregation_strategy="simple",
-                ),
-            )
-        except Exception as exc:  # pragma: no cover - runtime safety
-            logger.exception("Failed to load medical HF model: %s", exc)
-            _MEDICAL_MODEL = None
+    if _MEDICAL_MODEL is None:
+        _MEDICAL_MODEL = load_ner_model("MEDICAL_MODEL", "MEDICAL_MODEL")
     return _MEDICAL_MODEL
 
 
 def _load_legal_model() -> Tuple[str, Any] | None:
-    """Load a Legal-specific model based on environment variables."""
+    """Return the NER model for the Legal domain."""
 
     global _LEGAL_MODEL
-    if _LEGAL_MODEL is not None:
-        return _LEGAL_MODEL
-
-    library = (
-        get_config("NER_LIBRARY") or os.environ.get("NER_LIBRARY", "spacy")
-    ).lower()
-    if library == "spacy":
-        try:  # pragma: no cover - optional dependency
-            import spacy  # type: ignore
-
-            model_name = (
-                get_config("LEGAL_MODEL")
-                or os.environ.get("LEGAL_MODEL")
-                or get_config("SPACY_MODEL")
-                or os.environ.get("SPACY_MODEL", "en_core_web_sm")
-            )
-            _LEGAL_MODEL = ("spacy", spacy.load(model_name))
-        except Exception as exc:  # pragma: no cover - runtime safety
-            logger.exception("Failed to load legal spaCy model: %s", exc)
-            _LEGAL_MODEL = None
-    else:
-        try:  # pragma: no cover - optional dependency
-            from transformers import pipeline  # type: ignore
-
-            model_name = (
-                get_config("LEGAL_MODEL")
-                or os.environ.get("LEGAL_MODEL")
-                or get_config("HF_MODEL")
-                or os.environ.get("HF_MODEL", "dslim/bert-base-NER")
-            )
-            _LEGAL_MODEL = (
-                "hf",
-                pipeline(
-                    "ner",
-                    model=model_name,
-                    aggregation_strategy="simple",
-                ),
-            )
-        except Exception as exc:  # pragma: no cover - runtime safety
-            logger.exception("Failed to load legal HF model: %s", exc)
-            _LEGAL_MODEL = None
+    if _LEGAL_MODEL is None:
+        _LEGAL_MODEL = load_ner_model("LEGAL_MODEL", "LEGAL_MODEL")
     return _LEGAL_MODEL
 
 


### PR DESCRIPTION
## Summary
- centralize spaCy/HF NER model loading with `load_ner_model`
- expose `load_ner_model` through `common_utils`
- use the new helper in the sensitive info detection lambda
- update tests to mock the new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ef731db4832f953047345631d807