### PR TITLE
Add RAG architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Additional documentation is available in the `docs/` directory:
 - [docs/summarization_workflow.md](docs/summarization_workflow.md)
 - [docs/prompt_engine.md](docs/prompt_engine.md)
 - [docs/knowledge_rag_usage.md](docs/knowledge_rag_usage.md)
+- [docs/rag_architecture.md](docs/rag_architecture.md)
 - [docs/event_schemas.md](docs/event_schemas.md)
 - [docs/entity_tokenization_service.md](docs/entity_tokenization_service.md)
 - [docs/tokenization_workflow.md](docs/tokenization_workflow.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory contains guides and reference material for the services in this r
 - [summarization_workflow.md](summarization_workflow.md) – details of the summarization Step Function.
 - [prompt_engine.md](prompt_engine.md) – how prompts are stored and rendered.
 - [knowledge_rag_usage.md](knowledge_rag_usage.md) – ingesting and querying the knowledge base.
+- [rag_architecture.md](rag_architecture.md) – how ingestion, retrieval and summarization services interact.
 - [event_schemas.md](event_schemas.md) – sample payloads for Lambdas and Step Functions.
 - [entity_tokenization_service.md](entity_tokenization_service.md) – overview of the tokenization Lambda.
 - [tokenization_workflow.md](tokenization_workflow.md) – generating and rotating tokens securely.

--- a/docs/rag_architecture.md
+++ b/docs/rag_architecture.md
@@ -1,0 +1,36 @@
+# RAG Architecture Overview
+
+This guide illustrates how the retrieval augmented generation components connect across services. It covers document ingestion, embedding creation, vector search and summarization.
+
+## Components
+
+- **rag-ingestion** – chunks documents and generates embeddings.
+- **vector-db** – maintains Milvus collections used for semantic search.
+- **knowledge-base** – stores metadata for ingested chunks and exposes `/kb/*` endpoints.
+- **rag-retrieval** – performs vector search and orchestrates summarization with context.
+- **summarization** – Step Function workflow that can call retrieval functions when creating summaries.
+
+## End-to-End Flow
+
+The ingestion services generate embeddings and store metadata. Retrieval functions later query the vector database and pass the results to the summarization stack.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Ingestion as rag-ingestion
+    participant DB as vector-db
+    participant KB as knowledge-base
+    participant Retrieval as rag-retrieval
+    participant Sum as summarization
+
+    Client->>Ingestion: upload document
+    Ingestion->>DB: store embeddings
+    Ingestion->>KB: save chunk metadata
+    Client->>Retrieval: query for context
+    Retrieval->>DB: vector search
+    Retrieval->>KB: filter by metadata
+    Retrieval->>Sum: send top chunks
+    Sum-->>Client: return summary
+```
+
+The summarization Step Function may invoke retrieval during its workflow to supply relevant context before generating the final response. Both ingestion and retrieval rely on the `vector-db` service to manage Milvus collections.


### PR DESCRIPTION
## Summary
- document how rag-ingestion, rag-retrieval, knowledge-base, summarization and vector-db work together
- add mermaid sequence diagram for ingestion and retrieval
- link to the new docs from the documentation index and repo README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f31f4cc8832fbdcf955f5963d6da