### PR TITLE
Add RAG ingestion workflow doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory contains guides and reference material for the services in this r
 - [router_configuration.md](router_configuration.md) – LLM router parameters and heuristics.
 - [summarization_workflow.md](summarization_workflow.md) – details of the summarization Step Function.
 - [file_ingestion_workflow.md](file_ingestion_workflow.md) – how uploaded files are prepared before ingestion.
+- [rag_ingestion_workflow.md](rag_ingestion_workflow.md) – details of the ingestion Step Function.
 - [prompt_engine.md](prompt_engine.md) – how prompts are stored and rendered.
 - [knowledge_rag_usage.md](knowledge_rag_usage.md) – ingesting and querying the knowledge base.
 - [rag_architecture.md](rag_architecture.md) – how ingestion, retrieval and summarization services interact.

--- a/docs/rag_ingestion_workflow.md
+++ b/docs/rag_ingestion_workflow.md
@@ -1,0 +1,83 @@
+# RAG Ingestion Step Function Workflow
+
+This document describes the `IngestionStateMachine` defined in
+`services/rag-ingestion/template.yaml`. The workflow is triggered whenever a
+text document is uploaded under `TextDocPrefix` in the configured S3 bucket. It
+splits the text into chunks, generates embeddings and stores them in Milvus.
+
+```mermaid
+stateDiagram-v2
+    [*] --> TextChunk
+    TextChunk --> Embed
+    Embed --> MilvusInsert
+```
+
+## States
+
+**TextChunk**
+: Invokes `text-chunk-lambda` to split the input text into overlapping chunks.
+  The resulting list is forwarded to the next state.
+
+**Embed**
+: Calls `embed-lambda` for each chunk to compute vector embeddings.
+
+**MilvusInsert**
+: Sends the embeddings to the Milvus insert Lambda which stores them along with
+  any metadata, ending the workflow.
+
+## Chunk Strategy
+
+`text-chunk-lambda` supports two approaches for breaking documents into
+manageable pieces. By default it uses a simple paragraph and sentence based
+algorithm implemented by `chunk_text`. When the `universal` strategy is
+selected the `UniversalFileChunker` from `common/chunking` is used. This
+specialised chunker can detect Jupyter notebooks and common code formats.
+
+The strategy is resolved using the following inputs:
+
+- `chunkStrategy` field in the event payload
+- `CHUNK_STRATEGY_MAP` mapping `docType` to a strategy
+- fallback `CHUNK_STRATEGY` environment variable
+
+```mermaid
+flowchart TD
+    A{Resolve strategy} -->|chunkStrategy param| B[use provided value]
+    A -->|docType mapped| C[use CHUNK_STRATEGY_MAP]
+    A -->|otherwise| D[use CHUNK_STRATEGY]
+    B --> E
+    C --> E
+    D --> E
+    E{Strategy} -->|universal| F[UniversalFileChunker]
+    E -->|simple| G[chunk_text]
+```
+
+The chunk size and overlap come from `CHUNK_SIZE` and `CHUNK_OVERLAP` (defaults
+`1000` and `100`). When `EXTRACT_ENTITIES` is true, named entities are added to
+each chunk's metadata.
+
+## Embedding Strategy
+
+`embed-lambda` selects the embedding model in a similar manner. The default is
+`sbert` but a per-document override can be supplied. Supported models include
+SBERT, OpenAI and Cohere.
+
+```mermaid
+flowchart TD
+    M{Resolve model} -->|embedModel param| N[use provided value]
+    M -->|docType mapped| O[use EMBED_MODEL_MAP]
+    M -->|otherwise| P[use EMBED_MODEL]
+    N --> Q
+    O --> Q
+    P --> Q
+    Q{Model} -->|sbert| R[SBERT]
+    Q -->|openai| S[OpenAI]
+    Q -->|cohere| T[Cohere]
+```
+
+Environment variables used:
+
+- `EMBED_MODEL` and optional `EMBED_MODEL_MAP`
+- `SBERT_MODEL`, `OPENAI_EMBED_MODEL`, `COHERE_SECRET_NAME`
+
+The lambda embeds each chunk with the resolved provider and forwards the
+embeddings and metadata to the Milvus insert step.


### PR DESCRIPTION
## Summary
- document the IngestionStateMachine used by rag-ingestion
- add mermaid diagram for TextChunk -> Embed -> MilvusInsert
- include new page in documentation index
- expand documentation with chunking/embedding strategies and decision flows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867fdd70d94832f9cc43a7924c8fb25