### PR TITLE
Update service docs with workflow links

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -14,6 +14,8 @@ Copies uploaded files to the IDP bucket and waits for text extraction results be
 - **Lambdas:** `file-processing-lambda`, `file-processing-status-lambda`
 - **State machine:** `FileIngestionStateMachine` orchestrates the flow
 
+See the [file ingestion workflow](../docs/file_ingestion_workflow.md) for an overview.
+
 ## idp
 Complete Intelligent Document Processing pipeline performing classification, page splitting, text extraction and OCR before posting JSON output to an external API.
 
@@ -31,6 +33,8 @@ Splits text into overlapping chunks, generates embeddings and stores them in Mil
 
 - **Lambdas:** `text-chunk-lambda`, `embed-lambda`
 - Exports the ingestion state machine for other stacks
+
+For a detailed workflow, see [../docs/rag_ingestion_workflow.md](../docs/rag_ingestion_workflow.md).
 
 ## vector-db
 Manages Milvus collections and provides search functions.


### PR DESCRIPTION
## Summary
- link file-ingestion section to the file ingestion workflow doc
- link rag-ingestion section to the RAG ingestion workflow doc

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680194c058832f8fc9ee7a61c8938e