### PR TITLE
Add Docker support

### DIFF
--- a/services/entity-tokenization/Dockerfile
+++ b/services/entity-tokenization/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/entity-tokenization /var/task
+CMD ["python", "tokenize-entity-lambda/app.py"]

--- a/services/entity-tokenization/README.md
+++ b/services/entity-tokenization/README.md
@@ -29,3 +29,12 @@ sam deploy --template-file services/entity-tokenization/template.yaml --stack-na
 
 The stack exports `TokenizeEntityFunctionArn` and `TokenTableName` for use by
 other services.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/entity-tokenization/docker-compose.yml
+++ b/services/entity-tokenization/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/entity-tokenization/Dockerfile
+    environment:
+      TOKEN_TABLE: token-table
+      TOKEN_PREFIX: ent_
+      TOKEN_SALT: ''
+    ports:
+      - "9000:8080"

--- a/services/file-assembly/Dockerfile
+++ b/services/file-assembly/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/file-assembly /var/task
+CMD ["python", "file-assemble-lambda/app.py"]

--- a/services/file-assembly/README.md
+++ b/services/file-assembly/README.md
@@ -24,3 +24,12 @@ sam deploy \
   --template-file services/file-assembly/template.yaml \
   --stack-name file-assembly
 ```
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/file-assembly/docker-compose.yml
+++ b/services/file-assembly/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/file-assembly/Dockerfile
+    environment:
+      AWS_ACCOUNT_NAME: dev
+    ports:
+      - "9001:8080"

--- a/services/file-ingestion/Dockerfile
+++ b/services/file-ingestion/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/file-ingestion /var/task
+CMD ["python", "file-processing-lambda/app.py"]

--- a/services/file-ingestion/README.md
+++ b/services/file-ingestion/README.md
@@ -44,3 +44,12 @@ sam deploy \
     IDPRawPrefix=<prefix> \
     IngestionStateMachineArn=<arn>
 ```
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/file-ingestion/docker-compose.yml
+++ b/services/file-ingestion/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/file-ingestion/Dockerfile
+    environment:
+      AWS_ACCOUNT_NAME: dev
+      IDP_BUCKET: bucket
+      RAW_PREFIX: uploads/
+    ports:
+      - "9002:8080"

--- a/services/idp/Dockerfile
+++ b/services/idp/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/idp /var/task
+CMD ["python", "1-classifier/app.py"]

--- a/services/idp/README.md
+++ b/services/idp/README.md
@@ -66,3 +66,12 @@ Deploy the stack with SAM:
 ```bash
 sam deploy --template-file services/idp/template.yaml
 ```
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/idp/docker-compose.yml
+++ b/services/idp/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/idp/Dockerfile
+    environment:
+      BUCKET_NAME: data-bucket
+      OCR_ENGINE: easyocr
+    ports:
+      - "9003:8080"

--- a/services/knowledge-base/Dockerfile
+++ b/services/knowledge-base/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/knowledge-base /var/task
+CMD ["python", "query-lambda/app.py"]

--- a/services/knowledge-base/README.md
+++ b/services/knowledge-base/README.md
@@ -54,3 +54,12 @@ sam deploy \
     FileIngestionStateMachineArn=<arn> \
     SummarizeQueueUrl=<url>
 ```
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/knowledge-base/docker-compose.yml
+++ b/services/knowledge-base/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/knowledge-base/Dockerfile
+    environment:
+      STATE_MACHINE_ARN: arn:aws:states:region:acct:stateMachine:sm
+    ports:
+      - "9004:8080"

--- a/services/llm-invocation/Dockerfile
+++ b/services/llm-invocation/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/llm-invocation /var/task
+CMD ["python", "invoke-lambda/app.py"]

--- a/services/llm-invocation/README.md
+++ b/services/llm-invocation/README.md
@@ -50,3 +50,12 @@ aws lambda invoke \
 ```
 
 If `system_prompt` is provided it will be sent as the system message to the backend.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/llm-invocation/docker-compose.yml
+++ b/services/llm-invocation/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/llm-invocation/Dockerfile
+    environment:
+      BEDROCK_OPENAI_ENDPOINTS: http://localhost
+    ports:
+      - "9005:8080"

--- a/services/llm-router/Dockerfile
+++ b/services/llm-router/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/llm-router /var/task
+CMD ["python", "router-lambda/app.py"]

--- a/services/llm-router/README.md
+++ b/services/llm-router/README.md
@@ -79,3 +79,12 @@ The heuristic strategy is implemented by the `HeuristicRouter` module in the
 shared layer.  By default it chooses Bedrock once the prompt length exceeds
 `PROMPT_COMPLEXITY_THRESHOLD` words. Additional rules can be supplied via the
 `HEURISTIC_ROUTER_CONFIG` environment variable.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/llm-router/docker-compose.yml
+++ b/services/llm-router/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/llm-router/Dockerfile
+    environment:
+      LLM_INVOCATION_FUNCTION: invoke-llm
+    ports:
+      - "9006:8080"

--- a/services/prompt-engine/Dockerfile
+++ b/services/prompt-engine/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/prompt-engine /var/task
+CMD ["python", "prompt-engine-lambda/app.py"]

--- a/services/prompt-engine/README.md
+++ b/services/prompt-engine/README.md
@@ -62,3 +62,12 @@ Send a payload containing the desired `prompt_id` and variables to render:
 The summarization workflow can also provide `prompt_id` and `variables` for each
 entry in `body.prompts`. The worker Lambda forwards this data to the prompt
 engine before generating the summary.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/prompt-engine/docker-compose.yml
+++ b/services/prompt-engine/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/prompt-engine/Dockerfile
+    environment:
+      PROMPT_LIBRARY_TABLE: prompts
+      ROUTER_ENDPOINT: http://router
+    ports:
+      - "9007:8080"

--- a/services/rag-ingestion/Dockerfile
+++ b/services/rag-ingestion/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/rag-ingestion /var/task
+CMD ["python", "embed-lambda/app.py"]

--- a/services/rag-ingestion/README.md
+++ b/services/rag-ingestion/README.md
@@ -54,3 +54,12 @@ sam deploy \
 ```
 
 The outputs include the ARNs of `text-chunk-lambda`, `embed-lambda` and the `IngestionStateMachine` for use in other stacks.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/rag-ingestion/docker-compose.yml
+++ b/services/rag-ingestion/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/rag-ingestion/Dockerfile
+    environment:
+      CHUNK_SIZE: '1000'
+    ports:
+      - "9008:8080"

--- a/services/rag-retrieval/Dockerfile
+++ b/services/rag-retrieval/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/rag-retrieval /var/task
+CMD ["python", "summarize-with-context-lambda/app.py"]

--- a/services/rag-retrieval/README.md
+++ b/services/rag-retrieval/README.md
@@ -78,3 +78,12 @@ sam deploy \
 The summarization Lambda forwards requests through the LLM router defined by
 `ROUTELLM_ENDPOINT`. Configure any router specific variables as described in
 [../../docs/router_configuration.md](../../docs/router_configuration.md).
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/rag-retrieval/docker-compose.yml
+++ b/services/rag-retrieval/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/rag-retrieval/Dockerfile
+    environment:
+      VECTOR_SEARCH_FUNCTION: vector-search
+    ports:
+      - "9009:8080"

--- a/services/sensitive-info-detection/Dockerfile
+++ b/services/sensitive-info-detection/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/sensitive-info-detection /var/task
+CMD ["python", "detect-sensitive-info-lambda/app.py"]

--- a/services/sensitive-info-detection/README.md
+++ b/services/sensitive-info-detection/README.md
@@ -58,3 +58,12 @@ sam deploy --template-file services/sensitive-info-detection/template.yaml --sta
 ```
 
 The output exports `DetectSensitiveInfoFunctionArn` which can be used by other services.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/sensitive-info-detection/docker-compose.yml
+++ b/services/sensitive-info-detection/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/sensitive-info-detection/Dockerfile
+    environment:
+      NER_LIBRARY: spacy
+    ports:
+      - "9010:8080"

--- a/services/summarization/Dockerfile
+++ b/services/summarization/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/summarization /var/task
+CMD ["python", "file-summary-lambda/app.py"]

--- a/services/summarization/README.md
+++ b/services/summarization/README.md
@@ -112,3 +112,12 @@ An example prompt is available in
 The queue worker passes ``llm_params`` to the ``llm-invocation`` Lambda which
 forwards ``system_prompt`` to the selected backend.
 
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/summarization/docker-compose.yml
+++ b/services/summarization/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/summarization/Dockerfile
+    environment:
+      FILE_ASSEMBLE_FUNCTION_ARN: arn:aws:lambda:region:acct:function:file-assemble
+    ports:
+      - "9011:8080"

--- a/services/text-anonymization/Dockerfile
+++ b/services/text-anonymization/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/text-anonymization /var/task
+CMD ["python", "anonymize-text-lambda/app.py"]

--- a/services/text-anonymization/README.md
+++ b/services/text-anonymization/README.md
@@ -51,3 +51,12 @@ sam deploy --template-file services/text-anonymization/template.yaml --stack-nam
 ```
 
 The stack exports `AnonymizeTextFunctionArn` for use by other services.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/text-anonymization/docker-compose.yml
+++ b/services/text-anonymization/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/text-anonymization/Dockerfile
+    environment:
+      ANON_MODE: mask
+    ports:
+      - "9012:8080"

--- a/services/vector-db/Dockerfile
+++ b/services/vector-db/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/vector-db /var/task
+CMD ["python", "vector-search-lambda/app.py"]

--- a/services/vector-db/README.md
+++ b/services/vector-db/README.md
@@ -54,3 +54,12 @@ The stack exports the ARNs of the search functions:
 These values are referenced by other services. For example, `rag-retrieval`
 sets the `VECTOR_SEARCH_FUNCTION` environment variable to one of these ARNs to
 toggle between pure vector search and hybrid search.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/vector-db/docker-compose.yml
+++ b/services/vector-db/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/vector-db/Dockerfile
+    environment:
+      MILVUS_HOST: localhost
+      MILVUS_PORT: '19530'
+    ports:
+      - "9013:8080"

--- a/services/zip-processing/Dockerfile
+++ b/services/zip-processing/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/zip-processing /var/task
+CMD ["python", "zip-creation-lambda/app.py"]

--- a/services/zip-processing/README.md
+++ b/services/zip-processing/README.md
@@ -51,3 +51,12 @@ sam deploy \
     FileProcessingStepFunctionIAMRole=<role-arn> \
     FileProcessingEmailId=<email>
 ```
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/zip-processing/docker-compose.yml
+++ b/services/zip-processing/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/zip-processing/Dockerfile
+    environment:
+      AWS_ACCOUNT_NAME: dev
+    ports:
+      - "9014:8080"


### PR DESCRIPTION
## Summary
- add Dockerfile per service for running lambda handlers locally
- add docker-compose.yml in each service folder
- document how to build and run containers in service READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686808ab20f0832fa61af04130421b1c