### PR TITLE
Add Docker Compose ECR workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ complete list of common variables used across the services.
 
 Deploy a service with `sam deploy --template-file services/<service>/template.yaml --stack-name <name>` and provide any required parameters. See each service's README for details.
 
+Container images for all services can be built and pushed to ECR using:
+
+```bash
+./scripts/push_ecr.sh <account-id> <region> [tag]
+```
+
+This does not alter the existing SAM deployment process but allows functions to reference ECR images if desired.
+
 ## Documentation
 
 Additional documentation is available in the `docs/` directory:
@@ -98,3 +106,4 @@ Additional documentation is available in the `docs/` directory:
 - [docs/environment_variables.md](docs/environment_variables.md)
 - [docs/file_ingestion_workflow.md](docs/file_ingestion_workflow.md)
 - [docs/rag_ingestion_workflow.md](docs/rag_ingestion_workflow.md)
+- [docs/ecr_deployment.md](docs/ecr_deployment.md)

--- a/docker-compose.ecr.yml
+++ b/docker-compose.ecr.yml
@@ -1,0 +1,77 @@
+version: '3.8'
+services:
+  entity-tokenization:
+    build:
+      context: .
+      dockerfile: services/entity-tokenization/Dockerfile
+    image: ${ECR_REGISTRY}/entity-tokenization:${TAG:-latest}
+  file-assembly:
+    build:
+      context: .
+      dockerfile: services/file-assembly/Dockerfile
+    image: ${ECR_REGISTRY}/file-assembly:${TAG:-latest}
+  file-ingestion:
+    build:
+      context: .
+      dockerfile: services/file-ingestion/Dockerfile
+    image: ${ECR_REGISTRY}/file-ingestion:${TAG:-latest}
+  idp:
+    build:
+      context: .
+      dockerfile: services/idp/Dockerfile
+    image: ${ECR_REGISTRY}/idp:${TAG:-latest}
+  knowledge-base:
+    build:
+      context: .
+      dockerfile: services/knowledge-base/Dockerfile
+    image: ${ECR_REGISTRY}/knowledge-base:${TAG:-latest}
+  llm-invocation:
+    build:
+      context: .
+      dockerfile: services/llm-invocation/Dockerfile
+    image: ${ECR_REGISTRY}/llm-invocation:${TAG:-latest}
+  llm-router:
+    build:
+      context: .
+      dockerfile: services/llm-router/Dockerfile
+    image: ${ECR_REGISTRY}/llm-router:${TAG:-latest}
+  prompt-engine:
+    build:
+      context: .
+      dockerfile: services/prompt-engine/Dockerfile
+    image: ${ECR_REGISTRY}/prompt-engine:${TAG:-latest}
+  rag-ingestion:
+    build:
+      context: .
+      dockerfile: services/rag-ingestion/Dockerfile
+    image: ${ECR_REGISTRY}/rag-ingestion:${TAG:-latest}
+  rag-retrieval:
+    build:
+      context: .
+      dockerfile: services/rag-retrieval/Dockerfile
+    image: ${ECR_REGISTRY}/rag-retrieval:${TAG:-latest}
+  sensitive-info-detection:
+    build:
+      context: .
+      dockerfile: services/sensitive-info-detection/Dockerfile
+    image: ${ECR_REGISTRY}/sensitive-info-detection:${TAG:-latest}
+  summarization:
+    build:
+      context: .
+      dockerfile: services/summarization/Dockerfile
+    image: ${ECR_REGISTRY}/summarization:${TAG:-latest}
+  text-anonymization:
+    build:
+      context: .
+      dockerfile: services/text-anonymization/Dockerfile
+    image: ${ECR_REGISTRY}/text-anonymization:${TAG:-latest}
+  vector-db:
+    build:
+      context: .
+      dockerfile: services/vector-db/Dockerfile
+    image: ${ECR_REGISTRY}/vector-db:${TAG:-latest}
+  zip-processing:
+    build:
+      context: .
+      dockerfile: services/zip-processing/Dockerfile
+    image: ${ECR_REGISTRY}/zip-processing:${TAG:-latest}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,4 @@ This directory contains guides and reference material for the services in this r
 - [entity_tokenization_service.md](entity_tokenization_service.md) – overview of the tokenization Lambda.
 - [tokenization_workflow.md](tokenization_workflow.md) – generating and rotating tokens securely.
 - [environment_variables.md](environment_variables.md) – common Lambda configuration.
+- [ecr_deployment.md](ecr_deployment.md) – building and pushing container images.

--- a/docs/ecr_deployment.md
+++ b/docs/ecr_deployment.md
@@ -1,0 +1,26 @@
+# Deploying Lambda Container Images to ECR
+
+This repository can build all service images for AWS Elastic Container Registry (ECR) using Docker Compose. The container images can then be referenced by your SAM templates or deployed directly as Lambda functions.
+
+## Prerequisites
+
+- Run `sam build` to generate all Lambda layers under `common/layers`.
+- Docker must be authenticated to your AWS account.
+
+## Building and Pushing Images
+
+Use the helper script `scripts/push_ecr.sh` to log in to ECR and push all images defined in `docker-compose.ecr.yml`:
+
+```bash
+./scripts/push_ecr.sh <account-id> <region> [tag]
+```
+
+The script builds each service image and pushes it to `ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/<service>:TAG`. The optional `TAG` defaults to `latest`.
+
+## Example
+
+```bash
+./scripts/push_ecr.sh 123456789012 us-east-1 v1
+```
+
+After pushing, the images can be referenced from your Lambda function configurations without affecting the existing SAM-based deployment process.

--- a/scripts/push_ecr.sh
+++ b/scripts/push_ecr.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <account-id> <region> [tag]" >&2
+  exit 1
+fi
+
+ACCOUNT_ID="$1"
+REGION="$2"
+TAG="${3:-latest}"
+ECR_REGISTRY="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+export ECR_REGISTRY TAG
+
+aws ecr get-login-password --region "$REGION" \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+docker compose -f docker-compose.ecr.yml build
+
+docker compose -f docker-compose.ecr.yml push

--- a/services/entity-tokenization/Dockerfile
+++ b/services/entity-tokenization/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/file-assembly/Dockerfile
+++ b/services/file-assembly/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/file-ingestion/Dockerfile
+++ b/services/file-ingestion/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/idp/Dockerfile
+++ b/services/idp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/knowledge-base/Dockerfile
+++ b/services/knowledge-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/llm-invocation/Dockerfile
+++ b/services/llm-invocation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/llm-router/Dockerfile
+++ b/services/llm-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/prompt-engine/Dockerfile
+++ b/services/prompt-engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/rag-ingestion/Dockerfile
+++ b/services/rag-ingestion/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/rag-retrieval/Dockerfile
+++ b/services/rag-retrieval/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/sensitive-info-detection/Dockerfile
+++ b/services/sensitive-info-detection/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/summarization/Dockerfile
+++ b/services/summarization/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/text-anonymization/Dockerfile
+++ b/services/text-anonymization/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/vector-db/Dockerfile
+++ b/services/vector-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +

--- a/services/zip-processing/Dockerfile
+++ b/services/zip-processing/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /var/task
 COPY common/layers /opt/layers
 RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +


### PR DESCRIPTION
## Summary
- add `docker-compose.ecr.yml` that builds all services for ECR
- add helper script `push_ecr.sh` to login and push images
- document the workflow in `docs/ecr_deployment.md`
- link new documentation from README files and mention the script in main README
- align service Dockerfiles with `python:3.13-slim`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680d7b24b4832f91dc5d81fe03d009