### PR TITLE
Add Lambda image deployment script

### DIFF
--- a/docs/ecr_deployment.md
+++ b/docs/ecr_deployment.md
@@ -55,5 +55,14 @@ aws lambda update-function-code --function-name <name> \
   --image-uri <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/<service>:<tag>
 ```
 
+Instead of typing the full command each time, you can run the helper script
+`scripts/deploy_lambda_image.sh` which constructs the image URI automatically:
+
+```bash
+./scripts/deploy_lambda_image.sh <function-name> <account-id> <region> [tag]
+```
+
+The optional `tag` defaults to `latest`.
+
 You can find the correct URI with `aws ecr describe-images` or from the output
 of `scripts/push_ecr.sh`.

--- a/scripts/deploy_lambda_image.sh
+++ b/scripts/deploy_lambda_image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./scripts/deploy_lambda_image.sh <function-name> <account-id> <region> [tag]
+#
+# Update a Lambda function to use a container image stored in ECR. The optional
+# tag defaults to "latest".
+
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <function-name> <account-id> <region> [tag]" >&2
+  exit 1
+fi
+
+FUNCTION_NAME="$1"
+ACCOUNT_ID="$2"
+REGION="$3"
+TAG="${4:-latest}"
+IMAGE_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${FUNCTION_NAME}:${TAG}"
+
+aws lambda update-function-code --function-name "$FUNCTION_NAME" --image-uri "$IMAGE_URI"
+


### PR DESCRIPTION
## Summary
- add `deploy_lambda_image.sh` helper script for updating Lambda functions with an ECR image
- document how to use the new helper in the ECR deployment guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682050ea6c832fb9d01a911f30521c