### PR TITLE
Enable EFS paths via Parameter Store

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,20 @@ cd aio-enterprise-ai-services
 ## Dependency Layers
 Each Lambda's Python dependencies are packaged in a layer under `common/layers/`. When you run `sam build` these layers are automatically created and attached to the functions. No additional `pip` install steps are required at the repository root.
 
+### Using EFS for Dependencies and Models
+
+When Lambdas exceed the 250 MB uncompressed package limit, mount an EFS access point
+and install Python packages to the shared volume:
+
+```bash
+pip install -r requirements.txt -t /mnt/efs/python
+```
+
+Copy any large ML models to `/mnt/efs/models` and set the environment variables
+`EFS_DEPENDENCY_PATH=/mnt/efs/python` and `MODEL_EFS_PATH=/mnt/efs/models` (or
+store these values in Parameter Store) so the functions can locate them at
+runtime.
+
 ## Deploying a Service
 Navigate to the desired service directory and run `sam deploy` with any required parameters. For example, to deploy the file assembly service:
 ```bash

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Container images for all services can be built and pushed to ECR using:
 
 This does not alter the existing SAM deployment process but allows functions to reference ECR images if desired.
 
+If your dependencies or models exceed the Lambda package limit, mount an EFS access
+point and install the packages to that volume. Set the environment variables
+`EFS_DEPENDENCY_PATH` and `MODEL_EFS_PATH` (or provide them via Parameter Store)
+so services can import modules and load models directly from EFS.
+
 ## Documentation
 
 Additional documentation is available in the `docs/` directory:

--- a/common/layers/common-utils/python/common_utils/__init__.py
+++ b/common/layers/common-utils/python/common_utils/__init__.py
@@ -3,6 +3,10 @@ __author__ = "Koushik Sinha"
 __version__ = "1.0.0"
 __modified_by__ = "Koushik Sinha"
 
+import os
+import sys
+import site
+
 from .logging_utils import configure_logger
 from .get_ssm import (
     get_values_from_ssm,
@@ -10,6 +14,18 @@ from .get_ssm import (
     parse_s3_uri,
     get_config,
 )
+
+# Optional path to Python packages installed on an attached EFS volume.
+_EFS_DEPENDENCY_PATH = os.environ.get("EFS_DEPENDENCY_PATH") or get_config(
+    "EFS_DEPENDENCY_PATH"
+)
+if _EFS_DEPENDENCY_PATH:
+    for p in (_EFS_DEPENDENCY_PATH, os.path.join(_EFS_DEPENDENCY_PATH, "python")):
+        if os.path.isdir(p) and p not in sys.path:
+            site.addsitedir(p)
+
+# Optional base directory for models stored on EFS.
+MODEL_EFS_PATH = os.environ.get("MODEL_EFS_PATH") or get_config("MODEL_EFS_PATH")
 from .get_secret import get_secret
 from .milvus_client import MilvusClient, VectorItem, SearchResult, GetResult
 from .elasticsearch_client import ElasticsearchClient

--- a/common/layers/common-utils/python/common_utils/ner_models.py
+++ b/common/layers/common-utils/python/common_utils/ner_models.py
@@ -8,6 +8,8 @@ from typing import Any, Tuple
 from common_utils import configure_logger
 from common_utils.get_ssm import get_config
 
+MODEL_EFS_PATH = os.environ.get("MODEL_EFS_PATH") or get_config("MODEL_EFS_PATH")
+
 logger = configure_logger(__name__)
 
 # Cache keyed by (spacy_env, hf_env)
@@ -32,6 +34,10 @@ def load_ner_model(spacy_env: str, hf_env: str, default: str = "en_core_web_sm")
                 or get_config("SPACY_MODEL")
                 or os.environ.get("SPACY_MODEL", default)
             )
+            if MODEL_EFS_PATH:
+                efs_candidate = os.path.join(MODEL_EFS_PATH, os.path.basename(model_name))
+                if os.path.exists(efs_candidate):
+                    model_name = efs_candidate
             _MODEL_CACHE[key] = ("spacy", spacy.load(model_name))
         except Exception as exc:  # pragma: no cover - runtime safety
             logger.exception("Failed to load spaCy model: %s", exc)
@@ -46,6 +52,10 @@ def load_ner_model(spacy_env: str, hf_env: str, default: str = "en_core_web_sm")
                 or get_config("HF_MODEL")
                 or os.environ.get("HF_MODEL", "dslim/bert-base-NER")
             )
+            if MODEL_EFS_PATH:
+                efs_candidate = os.path.join(MODEL_EFS_PATH, os.path.basename(model_name))
+                if os.path.exists(efs_candidate):
+                    model_name = efs_candidate
             _MODEL_CACHE[key] = (
                 "hf",
                 pipeline("ner", model=model_name, aggregation_strategy="simple"),

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -108,4 +108,11 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `TOKEN_API_URL` – endpoint for tokenization when using token mode.
 - `ANON_TIMEOUT` – seconds before falling back to `[REMOVED]`.
 
+### EFS Storage
+
+- `EFS_DEPENDENCY_PATH` – mount location containing Python packages installed on EFS.
+- `MODEL_EFS_PATH` – base directory on EFS holding ML model files.
+
+Both variables may also be supplied via Parameter Store using the same names.
+
 See [services/text-anonymization/README.md](../services/text-anonymization/README.md) for more details.

--- a/services/rag-ingestion/embed-lambda/app.py
+++ b/services/rag-ingestion/embed-lambda/app.py
@@ -44,6 +44,11 @@ def _sbert_embed(text: str) -> List[float]:
             get_config("SBERT_MODEL")
             or os.environ.get("SBERT_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
         )
+        efs_dir = get_config("MODEL_EFS_PATH") or os.environ.get("MODEL_EFS_PATH")
+        if efs_dir:
+            candidate = os.path.join(efs_dir, os.path.basename(model_path))
+            if os.path.exists(candidate):
+                model_path = candidate
         if model_path.startswith("s3://"):
             import boto3
             from common_utils import parse_s3_uri

--- a/services/rag-retrieval/README.md
+++ b/services/rag-retrieval/README.md
@@ -32,11 +32,13 @@ The retrieval logic calls the search Lambda defined by the `VECTOR_SEARCH_FUNCTI
 - `CROSS_ENCODER_MODEL` – model name or S3 path for the cross-encoder.
 - `CROSS_ENCODER_EFS_PATH` – local path to load the cross encoder from an
   attached EFS volume.
+- `MODEL_EFS_PATH` – base directory on EFS for additional models.
 - `RERANK_PROVIDER` – rerank provider (`huggingface`, `cohere` or `nvidia`).
 - `NVIDIA_SECRET_NAME` – name or ARN of the NVIDIA API key secret.
 - `VECTOR_SEARCH_CANDIDATES` – number of candidates retrieved before re-ranking.
 
 Values can be stored in Parameter Store and loaded with the shared `get_config` helper.
+`CROSS_ENCODER_EFS_PATH` and `MODEL_EFS_PATH` may also be provided via Parameter Store.
 
 ## Mounting an EFS access point
 

--- a/services/rag-retrieval/rerank-lambda/app.py
+++ b/services/rag-retrieval/rerank-lambda/app.py
@@ -109,6 +109,12 @@ def _load_model():
     if _CE_MODEL is not None:
         return _CE_MODEL
     model_path = EFS_MODEL_PATH or DEFAULT_MODEL
+    if not EFS_MODEL_PATH:
+        base = get_config("MODEL_EFS_PATH") or os.environ.get("MODEL_EFS_PATH")
+        if base:
+            candidate = os.path.join(base, os.path.basename(DEFAULT_MODEL))
+            if os.path.exists(candidate):
+                model_path = candidate
     try:
         if model_path.startswith("s3://"):
             import boto3

--- a/services/rag-retrieval/summarize-with-context-lambda/app.py
+++ b/services/rag-retrieval/summarize-with-context-lambda/app.py
@@ -66,6 +66,11 @@ def _sbert_embed(text: str) -> list[float]:
             get_config("SBERT_MODEL")
             or os.environ.get("SBERT_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
         )
+        efs_dir = get_config("MODEL_EFS_PATH") or os.environ.get("MODEL_EFS_PATH")
+        if efs_dir:
+            candidate = os.path.join(efs_dir, os.path.basename(model_path))
+            if os.path.exists(candidate):
+                model_path = candidate
         if model_path.startswith("s3://"):
             import boto3
             from common_utils import parse_s3_uri


### PR DESCRIPTION
## Summary
- allow `EFS_DEPENDENCY_PATH` and `MODEL_EFS_PATH` to be read from SSM Parameter Store
- fall back to these SSM values when loading embeddings and cross encoder models
- document that both variables can be set via Parameter Store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686853e054c8832fac68b1d9de48f34a