### PR TITLE
Switch to random document IDs

### DIFF
--- a/common/layers/common-utils/python/models.py
+++ b/common/layers/common-utils/python/models.py
@@ -64,6 +64,7 @@ class S3Event:
     """Wrapper for S3 event records used by the IDP Lambdas."""
 
     Records: List[Dict[str, Any]]
+    document_id: Optional[str] = None
 
 
 @dataclass

--- a/docs/file_ingestion_workflow.md
+++ b/docs/file_ingestion_workflow.md
@@ -42,6 +42,8 @@ stateDiagram-v2
   `arn:aws:states:::lambda:invoke`. The entire event is forwarded as the payload
   so the lambda can copy the uploaded file from the staging bucket into
   `IDP_BUCKET/RAW_PREFIX`. A retry policy handles transient Lambda errors.
+  The handler assigns a new random `document_id` using `uuid.uuid4().hex` and
+  includes it in the response for downstream services.
 
 **Wait**
 : Waits `StatusPollSeconds` seconds before checking the file's status again.

--- a/services/file-ingestion/file-processing-lambda/app.py
+++ b/services/file-ingestion/file-processing-lambda/app.py
@@ -153,7 +153,7 @@ def process_files(event: FileProcessingEvent, context) -> dict:
         except AttributeError:
             logger.warning("S3 client not available for deletion of %s/%s", bucket_name, bucket_key)
 
-        document_id = os.path.splitext(os.path.basename(bucket_key))[0]
+        document_id = uuid.uuid4().hex
         file_name = os.path.basename(bucket_key)
         file_guid = uuid.uuid4().hex
 

--- a/tests/test_file_processing_lambda.py
+++ b/tests/test_file_processing_lambda.py
@@ -26,7 +26,7 @@ def test_file_processing_lambda(monkeypatch, s3_stub, config):
     resp = module.lambda_handler(event, {})
     assert resp['statusCode'] == 200
     body = resp['body']
-    assert body['document_id'] == 'test'
+    assert len(body['document_id']) == 32 and all(c in '0123456789abcdef' for c in body['document_id'])
     assert body['s3_location'] == 's3://dest-bucket/raw/test.docx'
     assert body['collection_name'] == 'c'
     # ensure the source file was removed after processing

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -41,6 +41,7 @@ def test_office_extractor(monkeypatch, s3_stub, validate_schema, config):
     monkeypatch.setattr(module, "_extract_xlsx", lambda b: ["## Page 1\n\ntext\n"])
 
     event = {
+        "document_id": "doc123",
         "Records": [
             {
                 "s3": {
@@ -52,9 +53,9 @@ def test_office_extractor(monkeypatch, s3_stub, validate_schema, config):
     }
     module.lambda_handler(event, {})
 
-    out_key = "text-docs/test.json"
+    out_key = "text-docs/doc123.json"
     payload = json.loads(s3_stub.objects[("bucket", out_key)].decode())
-    assert payload["documentId"] == "test"
+    assert payload["documentId"] == "doc123"
     assert payload["pageCount"] == 1
     page = {
         "documentId": payload["documentId"],


### PR DESCRIPTION
## Summary
- generate document IDs with `uuid.uuid4().hex`
- carry the ID in S3Event payloads
- accept provided IDs in Office extractor and PDF splitter
- adjust tests for the new ID format
- document new random `document_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685bb381d0832faa5cc3d9b054f1d2