### PR TITLE
Add rag-ingestion-worker service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.13] - 2025-07-04
+### Added
+- `rag-ingestion-worker` microservice that reads requests from SQS and triggers the RAG ingestion state machine.
+
 ## [1.0.12] - 2025-07-04
 ### Added
 - Dockerfiles and `docker-compose.yml` files for each service.

--- a/docs/event_schemas.md
+++ b/docs/event_schemas.md
@@ -155,3 +155,16 @@ Optionally include an `output_format` property to select `pdf`, `docx`, `json` o
   "department": "sales"
 }
 ```
+
+## RAG Ingestion Queue Message
+
+```json
+{
+  "text": "Document text",
+  "collection_name": "my-collection",
+  "docType": "pdf",
+  "department": "sales",
+  "team": "team1",
+  "user": "alice"
+}
+```

--- a/docs/rag_architecture.md
+++ b/docs/rag_architecture.md
@@ -5,6 +5,7 @@ This guide illustrates how the retrieval augmented generation components connect
 ## Components
 
 - **rag-ingestion** – chunks documents and generates embeddings.
+- **rag-ingestion-worker** – dequeues requests and starts the ingestion workflow.
 - **vector-db** – maintains Milvus collections used for semantic search.
 - **knowledge-base** – stores metadata for ingested chunks and exposes `/kb/*` endpoints.
 - **rag-retrieval** – performs vector search and orchestrates summarization with context.
@@ -34,3 +35,6 @@ sequenceDiagram
 ```
 
 The summarization Step Function may invoke retrieval during its workflow to supply relevant context before generating the final response. Both ingestion and retrieval rely on the `vector-db` service to manage Milvus collections.
+
+Ingestion requests can also be published to an SQS queue. The `rag-ingestion-worker`
+Lambda polls this queue and triggers the `IngestionStateMachine` for each message.

--- a/services/README.md
+++ b/services/README.md
@@ -36,6 +36,12 @@ Splits text into overlapping chunks, generates embeddings and stores them in Mil
 
 For a detailed workflow, see [../docs/rag_ingestion_workflow.md](../docs/rag_ingestion_workflow.md).
 
+## rag-ingestion-worker
+Dequeues ingestion requests from SQS and starts the `IngestionStateMachine`.
+
+- **Lambda:** `worker-lambda`
+- Defines an SQS queue exported as `IngestionQueueUrl`
+
 ## vector-db
 Manages Milvus collections and provides search functions.
 

--- a/services/rag-ingestion-worker/Dockerfile
+++ b/services/rag-ingestion-worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.13-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/rag-ingestion-worker /var/task
+CMD ["python", "worker-lambda/app.py"]

--- a/services/rag-ingestion-worker/README.md
+++ b/services/rag-ingestion-worker/README.md
@@ -1,0 +1,43 @@
+# RAG Ingestion Worker
+
+This service dequeues ingestion requests from SQS and starts the
+`IngestionStateMachine` defined by the **rag-ingestion** stack. It is a
+lightweight bridge that allows other services to publish ingestion jobs without
+invoking the Step Function directly.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `QUEUE_URL` | URL of the SQS queue containing ingestion requests. |
+| `STATE_MACHINE_ARN` | ARN of the ingestion Step Function to start. |
+
+Each SQS message should contain the same fields accepted by the
+`knowledge-base` ingest API (for example `text`, `collection_name`, `docType`
+and optional metadata). The worker simply forwards the message body as the Step
+Function input.
+
+## Deployment
+
+Deploy with SAM:
+
+```bash
+sam deploy \
+  --template-file services/rag-ingestion-worker/template.yaml \
+  --stack-name rag-ingestion-worker \
+  --parameter-overrides \
+    AWSAccountName=<name> \
+    IngestionStateMachineArn=<arn>
+```
+
+The stack provisions an SQS queue and a Lambda function subscribed to it.
+`IngestionQueueUrl` is exported for other stacks to publish requests.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/rag-ingestion-worker/docker-compose.yml
+++ b/services/rag-ingestion-worker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/rag-ingestion-worker/Dockerfile
+    environment:
+      STATE_MACHINE_ARN: arn:aws:states:region:acct:stateMachine:ingest
+      QUEUE_URL: https://sqs.region.amazonaws.com/123/queue
+    ports:
+      - "9013:8080"

--- a/services/rag-ingestion-worker/template.yaml
+++ b/services/rag-ingestion-worker/template.yaml
@@ -1,0 +1,97 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Queue worker for the RAG ingestion workflow.
+
+Parameters:
+  AWSAccountName:
+    Type: String
+  LambdaSubnet1ID:
+    Type: String
+  LambdaSubnet2ID:
+    Type: String
+  LambdaSecurityGroupID1:
+    Type: String
+  LambdaSecurityGroupID2:
+    Type: String
+  LambdaIAMRoleARN:
+    Type: String
+  IngestionStateMachineArn:
+    Type: String
+
+Globals:
+  Function:
+    Timeout: 300
+    Tracing: Active
+    Runtime: python3.13
+    Architectures:
+      - x86_64
+    LoggingConfig:
+      LogFormat: JSON
+
+Resources:
+  IngestionQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout: 300
+
+  WorkerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub '${AWSAccountName}-${AWS::StackName}-ingestion-worker'
+      Handler: app.lambda_handler
+      Runtime: python3.13
+      CodeUri: ./worker-lambda/
+      Role: !Ref LambdaIAMRoleARN
+      MemorySize: 512
+      Timeout: 300
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroupID1
+          - !Ref LambdaSecurityGroupID2
+        SubnetIds:
+          - !Ref LambdaSubnet1ID
+          - !Ref LambdaSubnet2ID
+      Environment:
+        Variables:
+          STATE_MACHINE_ARN: !Ref IngestionStateMachineArn
+          QUEUE_URL: !Ref IngestionQueue
+      Events:
+        Queue:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt IngestionQueue.Arn
+            BatchSize: 1
+
+  WorkerSQSPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub '${AWSAccountName}-${AWS::StackName}-worker-sqs'
+      Roles:
+        - !Select [1, !Split ['/', !Ref LambdaIAMRoleARN]]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:ReceiveMessage
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+            Resource: !GetAtt IngestionQueue.Arn
+
+  StepFunctionInvokePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub '${AWSAccountName}-${AWS::StackName}-sf-start'
+      Roles:
+        - !Select [1, !Split ['/', !Ref LambdaIAMRoleARN]]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: states:StartExecution
+            Resource: !Ref IngestionStateMachineArn
+
+Outputs:
+  IngestionQueueUrl:
+    Description: URL of the ingestion queue
+    Value: !Ref IngestionQueue

--- a/services/rag-ingestion-worker/worker-lambda/app.py
+++ b/services/rag-ingestion-worker/worker-lambda/app.py
@@ -1,0 +1,48 @@
+"""Worker Lambda triggering the RAG ingestion workflow from SQS messages."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+import boto3
+from common_utils import configure_logger
+from common_utils.get_ssm import get_config
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except Exception:  # pragma: no cover - allow missing botocore
+    BotoCoreError = ClientError = Exception  # type: ignore
+
+logger = configure_logger(__name__)
+
+sqs_client = boto3.client("sqs")
+sf_client = boto3.client("stepfunctions")
+
+STATE_MACHINE_ARN = get_config("STATE_MACHINE_ARN") or os.environ.get("STATE_MACHINE_ARN")
+QUEUE_URL = get_config("QUEUE_URL") or os.environ.get("QUEUE_URL")
+
+
+def _process_record(record: Dict[str, Any]) -> None:
+    body = json.loads(record.get("body", record.get("Body", "{}")))
+    try:
+        sf_client.start_execution(
+            stateMachineArn=STATE_MACHINE_ARN,
+            input=json.dumps(body),
+        )
+    except (ClientError, BotoCoreError) as exc:  # pragma: no cover - runtime issues
+        logger.exception("Failed to start ingestion state machine")
+        raise exc
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    records = event.get("Records")
+    if not records and QUEUE_URL:
+        resp = sqs_client.receive_message(QueueUrl=QUEUE_URL, MaxNumberOfMessages=10)
+        records = resp.get("Messages", [])
+    for record in records or []:
+        _process_record(record)
+        if "ReceiptHandle" in record and QUEUE_URL:
+            sqs_client.delete_message(QueueUrl=QUEUE_URL, ReceiptHandle=record["ReceiptHandle"])
+    return {"statusCode": 200}

--- a/tests/test_ingestion_worker.py
+++ b/tests/test_ingestion_worker.py
@@ -1,0 +1,37 @@
+import importlib.util
+import json
+import sys
+
+
+def load_lambda(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_worker_starts_state_machine(monkeypatch):
+    monkeypatch.setenv("STATE_MACHINE_ARN", "arn")
+
+    started = {}
+
+    class FakeSF:
+        def start_execution(self, stateMachineArn=None, input=None):
+            started["arn"] = stateMachineArn
+            started["input"] = json.loads(input)
+
+    class FakeSQS:
+        def receive_message(self, **kwargs):
+            return {}
+        def delete_message(self, **kwargs):
+            pass
+
+    import boto3
+    monkeypatch.setattr(sys.modules["boto3"], "client", lambda name: FakeSF() if name == "stepfunctions" else FakeSQS())
+
+    module = load_lambda("worker", "services/rag-ingestion-worker/worker-lambda/app.py")
+    event = {"Records": [{"body": json.dumps({"text": "t", "collection_name": "c"})}]}
+    module.lambda_handler(event, {})
+
+    assert started["arn"] == "arn"
+    assert started["input"]["text"] == "t"


### PR DESCRIPTION
## Summary
- add rag-ingestion-worker microservice
- document the ingestion worker in services README and docs
- describe queue message schema
- implement unit test for the worker
- note new microservice in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694af272bc832f8d6114a97124466c