### PR TITLE
Expand RAG ingestion worker README

### DIFF
--- a/services/rag-ingestion-worker/README.md
+++ b/services/rag-ingestion-worker/README.md
@@ -41,3 +41,38 @@ Build and run with Docker Compose:
 docker compose build
 docker compose up
 ```
+
+## Queue configuration
+
+The stack provisions an `IngestionQueue` with a `VisibilityTimeout` of
+`300` seconds. This value should be at least as long as the Lambda timeout
+so that messages are not returned to the queue while they are still being
+processed. You can change the timeout in `template.yaml` if ingestion jobs
+regularly take longer.
+
+For production deployments it is recommended to attach a dead letter queue
+(DLQ) to `IngestionQueue` using an SQS `RedrivePolicy`. Messages that fail
+repeatedly will then be moved to the DLQ for manual inspection instead of
+being retried indefinitely.
+
+## Failure handling and retries
+
+`WorkerFunction` processes one message at a time (`BatchSize: 1`). If the
+Step Function execution fails and the Lambda invocation raises an error, the
+message remains on the queue and becomes visible again after the visibility
+timeout, triggering a retry. Because messages are deleted only after
+successful processing, the same payload is retried until it succeeds or
+exceeds the maximum receives configured by any DLQ.
+
+## Scaling the worker
+
+AWS Lambda automatically scales the number of concurrent executions based on
+the queue depth. To increase throughput you can raise the function's reserved
+concurrency or use a larger batch size. Each invocation requires the
+following environment variables:
+
+- `QUEUE_URL` – URL of the SQS queue.
+- `STATE_MACHINE_ARN` – ARN of the ingestion Step Function.
+
+Adjusting reserved concurrency controls how many ingestion workflows may run
+in parallel and therefore how quickly queued messages are drained.


### PR DESCRIPTION
## Summary
- document SQS visibility timeout and dead letter queues
- explain failure handling and retries
- add notes on scaling the ingestion worker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694a70f9c4832fae9c95aff68b0178