### PR TITLE
Update RAG docs for ingestion worker

### DIFF
--- a/docs/rag_ingestion_workflow.md
+++ b/docs/rag_ingestion_workflow.md
@@ -81,3 +81,11 @@ Environment variables used:
 
 The lambda embeds each chunk with the resolved provider and forwards the
 embeddings and metadata to the Milvus insert step.
+
+## Queue-based Invocation
+
+Large ingestion jobs may be placed on an SQS queue instead of calling the state
+machine directly. The `rag-ingestion-worker` Lambda monitors this queue and
+starts `IngestionStateMachine` for each message. Any failed messages are moved to
+`IngestionDLQ` and retried automatically. The queue URL is exported from the
+stack as `IngestionQueueUrl`.


### PR DESCRIPTION
## Summary
- describe new ingestion queue DLQ and batch handling
- show worker in architecture diagram
- mention queue-based invocation in the workflow doc
- note IngestionQueueUrl output in docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686953021288832fabfd289b68a1d6ae