### PR TITLE
Add llm-gateway service templates

### DIFF
--- a/services/llm-gateway/Dockerfile
+++ b/services/llm-gateway/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.13-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/llm-gateway /var/task
+CMD ["python", "src/llm_router_lambda.py"]

--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -1,0 +1,64 @@
+# LLM Gateway Service
+
+This consolidated service groups three Lambdas that work together to process Large Language Model requests.  Templates are rendered by the prompt engine, queued through the router and finally executed by the invocation function.
+
+## Lambdas
+
+- **prompt_engine_lambda.py** – loads a template from DynamoDB and forwards the rendered prompt to the router.
+- **llm_router_lambda.py** – selects a backend and places the request on the invocation queue.
+- **llm_invocation_lambda.py** – invokes Bedrock or Ollama and returns the raw response.
+
+## Parameters and environment variables
+
+`template.yaml` defines parameters for each Lambda that become environment variables.
+
+### prompt_engine_lambda
+
+| Parameter | Environment variable | Description |
+|-----------|---------------------|-------------|
+| `TableName` | `PROMPT_LIBRARY_TABLE` | DynamoDB table containing prompt templates |
+| `RouterEndpoint` | `ROUTER_ENDPOINT` | URL of the router service |
+| `LambdaSubnet1ID` / `LambdaSubnet2ID` | – | Subnets used by the Lambda |
+| `LambdaSecurityGroupID1` / `LambdaSecurityGroupID2` | – | Security groups attached to the Lambda |
+| `LambdaIAMRoleARN` | – | IAM role assumed by the function |
+
+### llm_router_lambda
+
+| Parameter | Environment variable | Description |
+|-----------|----------------------|-------------|
+| `BedrockOpenAIEndpoint` | `BEDROCK_OPENAI_ENDPOINTS` | Comma-separated Bedrock OpenAI endpoints |
+| `BedrockSecretName` | `BEDROCK_SECRET_NAME` | Name or ARN of the Bedrock API key secret |
+| `OllamaEndpoint` | `OLLAMA_ENDPOINTS` | URLs of Ollama services |
+| `OllamaDefaultModel` | `OLLAMA_DEFAULT_MODEL` | Default model when none supplied |
+| `PromptComplexityThreshold` | `PROMPT_COMPLEXITY_THRESHOLD` | Word threshold used by the heuristic router |
+| `LlmInvocationFunctionName` | `LLM_INVOCATION_FUNCTION` | Name of the invocation Lambda |
+| `ClassifierModelId` | `CLASSIFIER_MODEL_ID` | Optional model used for predictive routing |
+
+### llm_invocation_lambda
+
+Parameters mirror the environment variables controlling each backend. The most common ones are:
+
+- `BEDROCK_TEMPERATURE`, `BEDROCK_NUM_CTX`, `BEDROCK_MAX_TOKENS`,
+  `BEDROCK_TOP_P`, `BEDROCK_TOP_K`, `BEDROCK_MAX_TOKENS_TO_SAMPLE`
+- `OLLAMA_NUM_CTX`, `OLLAMA_REPEAT_LAST_N`, `OLLAMA_REPEAT_PENALTY`,
+  `OLLAMA_TEMPERATURE`, `OLLAMA_SEED`, `OLLAMA_STOP`, `OLLAMA_NUM_PREDICT`,
+  `OLLAMA_TOP_K`, `OLLAMA_TOP_P`, `OLLAMA_MIN_P`
+
+## Deployment
+
+Deploy the stack with SAM:
+
+```bash
+sam deploy --template-file services/llm-gateway/template.yaml --stack-name llm-gateway
+```
+
+The stack exports `PromptEngineFunctionArn`, `RouterFunctionArn` and `LlmInvocationFunctionArn` for use by other services.
+
+## Local testing
+
+Build and run with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/llm-gateway/docker-compose.yml
+++ b/services/llm-gateway/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/llm-gateway/Dockerfile
+    environment:
+      PROMPT_LIBRARY_TABLE: prompts
+      ROUTER_ENDPOINT: http://router
+      INVOCATION_QUEUE_URL: http://queue
+    ports:
+      - "9007:8080"

--- a/services/llm-gateway/template.yaml
+++ b/services/llm-gateway/template.yaml
@@ -1,0 +1,232 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Lambdas for rendering prompts, routing requests and invoking models.
+
+Parameters:
+  AWSAccountName:
+    Type: String
+    Description: AWS Account Name
+  LambdaSubnet1ID:
+    Type: String
+    Description: Subnet ID for Lambda function
+  LambdaSubnet2ID:
+    Type: String
+    Description: Subnet ID for Lambda function
+  LambdaSecurityGroupID1:
+    Type: String
+    Description: Security Group ID for Lambda functions
+  LambdaSecurityGroupID2:
+    Type: String
+    Description: Security Group ID for Lambda functions
+  LambdaIAMRoleARN:
+    Type: String
+    Description: IAM Role ARN for Lambda functions
+  TableName:
+    Type: String
+    Description: DynamoDB table storing prompt templates
+  RouterEndpoint:
+    Type: String
+    Description: URL of the router service
+  BedrockOpenAIEndpoint:
+    Type: String
+    Default: ''
+  BedrockSecretName:
+    Type: String
+    Default: ''
+  BedrockTemperature:
+    Type: String
+    Default: ''
+  BedrockNumCtx:
+    Type: String
+    Default: ''
+  BedrockMaxTokens:
+    Type: String
+    Default: ''
+  BedrockTopP:
+    Type: String
+    Default: ''
+  BedrockTopK:
+    Type: String
+    Default: ''
+  BedrockMaxTokensToSample:
+    Type: String
+    Default: ''
+  OllamaEndpoint:
+    Type: String
+    Default: ''
+  OllamaDefaultModel:
+    Type: String
+    Default: ''
+  OllamaNumCtx:
+    Type: String
+    Default: ''
+  OllamaRepeatLastN:
+    Type: String
+    Default: ''
+  OllamaRepeatPenalty:
+    Type: String
+    Default: ''
+  OllamaTemperature:
+    Type: String
+    Default: ''
+  OllamaSeed:
+    Type: String
+    Default: ''
+  OllamaStop:
+    Type: String
+    Default: ''
+  OllamaNumPredict:
+    Type: String
+    Default: ''
+  OllamaTopK:
+    Type: String
+    Default: ''
+  OllamaTopP:
+    Type: String
+    Default: ''
+  OllamaMinP:
+    Type: String
+    Default: ''
+  PromptComplexityThreshold:
+    Type: String
+    Default: '20'
+  ClassifierModelId:
+    Type: String
+    Default: ''
+  LlmInvocationFunctionName:
+    Type: String
+    Default: ''
+
+Globals:
+  Function:
+    Runtime: python3.13
+    Timeout: 60
+    MemorySize: 512
+
+Resources:
+  PromptLibraryTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Ref TableName
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+
+  RouterLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: llm-router-layer
+      Description: Helpers for router lambda
+      ContentUri: ../../common/layers/router-layer/
+      CompatibleRuntimes:
+        - python3.13
+      RetentionPolicy: Delete
+
+  LlmInvocationLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: llm-invocation-layer
+      Description: Helpers for invoking LLMs
+      ContentUri: ../../common/layers/llm-invocation-layer/
+      CompatibleRuntimes:
+        - python3.13
+      RetentionPolicy: Delete
+
+  PromptEngineFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src/
+      Handler: prompt_engine_lambda.lambda_handler
+      Role: !Ref LambdaIAMRoleARN
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroupID1
+          - !Ref LambdaSecurityGroupID2
+        SubnetIds:
+          - !Ref LambdaSubnet1ID
+          - !Ref LambdaSubnet2ID
+      Environment:
+        Variables:
+          PROMPT_LIBRARY_TABLE: !Ref TableName
+          ROUTER_ENDPOINT: !Ref RouterEndpoint
+          AWS_ACCOUNT_NAME: !Ref AWSAccountName
+
+  RouterFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src/
+      Handler: llm_router_lambda.lambda_handler
+      Layers:
+        - !Ref RouterLayer
+      Environment:
+        Variables:
+          BEDROCK_OPENAI_ENDPOINTS: !Ref BedrockOpenAIEndpoint
+          BEDROCK_SECRET_NAME: !Ref BedrockSecretName
+          OLLAMA_ENDPOINTS: !Ref OllamaEndpoint
+          OLLAMA_DEFAULT_MODEL: !Ref OllamaDefaultModel
+          PROMPT_COMPLEXITY_THRESHOLD: !Ref PromptComplexityThreshold
+          LLM_INVOCATION_FUNCTION: !Ref LlmInvocationFunctionName
+          CLASSIFIER_MODEL_ID: !Ref ClassifierModelId
+
+  LlmInvocationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src/
+      Handler: llm_invocation_lambda.lambda_handler
+      Layers:
+        - !Ref LlmInvocationLayer
+      Environment:
+        Variables:
+          BEDROCK_OPENAI_ENDPOINTS: !Ref BedrockOpenAIEndpoint
+          BEDROCK_SECRET_NAME: !Ref BedrockSecretName
+          BEDROCK_TEMPERATURE: !Ref BedrockTemperature
+          BEDROCK_NUM_CTX: !Ref BedrockNumCtx
+          BEDROCK_MAX_TOKENS: !Ref BedrockMaxTokens
+          BEDROCK_TOP_P: !Ref BedrockTopP
+          BEDROCK_TOP_K: !Ref BedrockTopK
+          BEDROCK_MAX_TOKENS_TO_SAMPLE: !Ref BedrockMaxTokensToSample
+          OLLAMA_ENDPOINTS: !Ref OllamaEndpoint
+          OLLAMA_DEFAULT_MODEL: !Ref OllamaDefaultModel
+          OLLAMA_NUM_CTX: !Ref OllamaNumCtx
+          OLLAMA_REPEAT_LAST_N: !Ref OllamaRepeatLastN
+          OLLAMA_REPEAT_PENALTY: !Ref OllamaRepeatPenalty
+          OLLAMA_TEMPERATURE: !Ref OllamaTemperature
+          OLLAMA_SEED: !Ref OllamaSeed
+          OLLAMA_STOP: !Ref OllamaStop
+          OLLAMA_NUM_PREDICT: !Ref OllamaNumPredict
+          OLLAMA_TOP_K: !Ref OllamaTopK
+          OLLAMA_TOP_P: !Ref OllamaTopP
+          OLLAMA_MIN_P: !Ref OllamaMinP
+
+  PromptEnginePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub '${AWSAccountName}-${AWS::StackName}-dynamo'
+      Roles:
+        - !Select [1, !Split ['/', !Ref LambdaIAMRoleARN]]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:GetItem
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+              - dynamodb:Scan
+              - dynamodb:Query
+            Resource: !GetAtt PromptLibraryTable.Arn
+
+Outputs:
+  PromptEngineFunctionArn:
+    Description: ARN of the prompt engine Lambda
+    Value: !GetAtt PromptEngineFunction.Arn
+  RouterFunctionArn:
+    Description: ARN of the router lambda
+    Value: !GetAtt RouterFunction.Arn
+  LlmInvocationFunctionArn:
+    Description: ARN of the invocation lambda
+    Value: !GetAtt LlmInvocationFunction.Arn


### PR DESCRIPTION
## Summary
- copy prompt-engine boilerplate for the llm-gateway service
- document prompt engine, router and invocation lambdas
- add consolidated SAM template
- install layers and run correct lambda in Dockerfile
- update docker compose for local development

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6869b4cd9e1c832fb397f18b3e599c02