### PR TITLE
Consolidate llm service docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ The repository includes the following directories under `services/`:
 - `vector-db` – manages Milvus collections and search Lambdas
 - `rag-retrieval` – retrieval functions and API endpoints for summarization or entity extraction
 - `summarization` – Step Function workflow orchestrating file processing and summary generation
-- `prompt-engine` – renders templates from DynamoDB and forwards them to the router
-- `llm-router` – routes prompts via heuristic, predictive and cascading strategies to Amazon Bedrock or local Ollama
-- `llm-invocation` – forwards OpenAI-style requests to a specific LLM backend
+- `llm-gateway` – renders templates and routes requests to the selected LLM backend
 - `knowledge-base` – ingest text snippets and query them through the retrieval stack
 - `sensitive-info-detection` – PII/PHI detection for text including legal entities
 - `entity-tokenization` – replaces sensitive entities with stable tokens

--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -1,6 +1,6 @@
 # Prompt Engine
 
-The prompt engine is a lightweight Lambda that renders text templates stored in a DynamoDB table and forwards the result to the LLM router. Templates are addressed by a `prompt_id` and `version` so multiple revisions can be stored.
+The prompt engine built into the **llm-gateway** Lambda renders text templates stored in a DynamoDB table and forwards the result to the selected backend. Templates are addressed by a `prompt_id` and `version` so multiple revisions can be stored.
 
 ## DynamoDB Items
 
@@ -56,7 +56,7 @@ aws dynamodb put-item \
 
 ## Invocation
 
-Send a JSON payload containing the desired `prompt_id` and any variables to the Lambda's endpoint. The rendered prompt is forwarded to the router service and the response is returned unchanged:
+Send a JSON payload containing the desired `prompt_id` and any variables to the Lambda's endpoint. The rendered prompt is forwarded to the gateway's target backend and the response is returned unchanged:
 
 ```json
 {"prompt_id": "summary-v1", "variables": {"text": "example content"}}

--- a/temp-services/README.md
+++ b/temp-services/README.md
@@ -59,25 +59,13 @@ Retrieves relevant context from the vector database and forwards it to summariza
 Orchestrates file ingestion, prompt execution and summary generation.
 
 - Generates PDF, DOCX, JSON or XML summaries
-- Integrates with the prompt engine using `workflow_id`
+- Integrates with the LLM Gateway using `workflow_id`
 
-## prompt-engine
-Renders prompt templates stored in DynamoDB and sends the final prompt to the LLM router.
+## llm-gateway
+Renders templates, routes prompts and forwards requests to the configured LLM backend.
 
 - Parameterised by `PromptLibraryTable` and `RouterEndpoint`
-- Accepts `prompt_id` and `variables` in requests
-
-## llm-router
-Routes prompts to Amazon Bedrock or a local Ollama instance using heuristic, predictive and cascading strategies.
-
-- Requests are queued on SQS for asynchronous processing
-- Returns which backend produced the response
-
-## llm-invocation
-Forwards OpenAI-style requests to the configured backend with optional system prompts.
-
-- Can be invoked directly or via the router queue
-- Uses dataclass models for type-safe payloads
+- Supports direct invocation or queued requests
 
 ## knowledge-base
 Provides a lightweight API to ingest short text documents and query them using the retrieval stack.

--- a/temp-services/llm-invocation/README.md
+++ b/temp-services/llm-invocation/README.md
@@ -1,5 +1,7 @@
 # LLM Invocation Service
 
+**Note:** this functionality has been consolidated into the `llm-gateway` service.
+
 This service exposes a single Lambda function that forwards OpenAI-style requests to a specific LLM backend. It is typically invoked by the LLM router but can also be called directly.
 The function can now be triggered asynchronously from an SQS queue used by the router service.
 

--- a/temp-services/llm-router/README.md
+++ b/temp-services/llm-router/README.md
@@ -1,5 +1,7 @@
 # LLM Router Service
 
+**Note:** routing logic is now included in the `llm-gateway` service.
+
 This service routes prompts to different Large Language Model backends such as Amazon Bedrock or a local Ollama instance. `router-lambda/app.py` implements the Lambda entry point and relies on utilities shipped in the shared layer `common/layers/router-layer`.
 
 Handler type hints reference dataclasses defined in ``models.py``:

--- a/temp-services/prompt-engine/README.md
+++ b/temp-services/prompt-engine/README.md
@@ -1,9 +1,11 @@
 # Prompt Engine Service
 
+**Note:** this functionality is now provided by the `llm-gateway` service.
+
 This service provides a simple Lambda for rendering prompts stored in a DynamoDB
  table. The function loads a template from `PromptLibraryTable`, substitutes
 variables passed in the request and forwards the final prompt to the LLM router
-specified by `RouterEndpoint`.
+ specified by `RouterEndpoint`.
 
 ## Parameters
 

--- a/temp-services/summarization/README.md
+++ b/temp-services/summarization/README.md
@@ -19,7 +19,7 @@ The SAM template exposes a few parameters which become environment variables for
 - `FileAssembleFunctionArn` – ARN of the file assembly Lambda used to merge summaries with the original PDF.
 - `RunPromptsConcurrency` – number of prompts processed in parallel by the `run_prompts` map state.
 - The service now provisions an SQS queue consumed by a worker Lambda. `RunPromptsConcurrency` controls how many messages are sent in parallel.
-- `PromptEngineEndpoint` – optional URL of the prompt engine service used for templated prompts.
+- `PromptEngineEndpoint` – optional URL of the LLM Gateway service used for templated prompts.
 
 
 ## Deployment
@@ -62,17 +62,17 @@ A unique `file_guid` is generated during the file-processing step. This value fl
 ## Prompt templates
 
 Each entry in `body.prompts` may specify a `prompt_id` that refers to a template
-stored in the prompt engine. When present, the worker Lambda sends
-`prompt_id` and an optional `variables` dictionary to the engine before invoking
-the summarization logic. The engine renders the template and forwards it to the
-LLM router, but the queue worker ignores the response – the original
+stored in the LLM Gateway. When present, the worker Lambda sends
+`prompt_id` and an optional `variables` dictionary to the gateway before invoking
+the summarization logic. The gateway renders the template and forwards it to the
+LLM backend, but the queue worker ignores the response – the original
 ``query`` value is still passed to ``RAG_SUMMARY_FUNCTION_ARN`` unchanged.
 
 ## `workflow_id`
 
 Instead of providing the prompts list directly you can specify a ``workflow_id``
 which references a stored set of prompts. The Step Function invokes the
-``load-prompts`` Lambda to fetch the list from the Prompt Engine before running
+``load-prompts`` Lambda to fetch the list from the LLM Gateway before running
 
 the summaries. The same Lambda also loads the workflow's system prompt and
 populates ``body.llm_params.system_prompt`` automatically.
@@ -109,7 +109,7 @@ Function execution. To supply a system prompt for the LLM add a
 
 An example prompt is available in
 [`file-summary-lambda/system_prompt.json`](file-summary-lambda/system_prompt.json).
-The queue worker passes ``llm_params`` to the ``llm-invocation`` Lambda which
+The queue worker passes ``llm_params`` to the ``llm-gateway`` Lambda which
 forwards ``system_prompt`` to the selected backend.
 
 


### PR DESCRIPTION
## Summary
- collapse router, invocation and prompt engine docs into a single `llm-gateway` entry
- update docs to reference `llm-gateway`

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6869b7e109ec832fb9c4cdce3aabb36e