### PR TITLE
Update docs for llm-gateway service

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ so services can import modules and load models directly from EFS.
 Additional documentation is available in the `docs/` directory:
 
 - [docs/idp_output_format.md](docs/idp_output_format.md)
-- [docs/router_configuration.md](docs/router_configuration.md)
+- [docs/router_configuration.md](docs/router_configuration.md) – LLM Gateway router parameters and heuristics
 - [docs/summarization_workflow.md](docs/summarization_workflow.md)
 - [docs/prompt_engine.md](docs/prompt_engine.md)
 - [docs/knowledge_rag_usage.md](docs/knowledge_rag_usage.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 This directory contains guides and reference material for the services in this repository.
 
 - [idp_output_format.md](idp_output_format.md) – JSON fields produced by the IDP pipeline.
-- [router_configuration.md](router_configuration.md) – LLM router parameters and heuristics.
+- [router_configuration.md](router_configuration.md) – LLM Gateway router parameters and heuristics.
 - [summarization_workflow.md](summarization_workflow.md) – details of the summarization Step Function.
 - [file_ingestion_workflow.md](file_ingestion_workflow.md) – how uploaded files are prepared before ingestion.
 - [rag_ingestion_workflow.md](rag_ingestion_workflow.md) – details of the ingestion Step Function.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -56,7 +56,7 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `SUMMARY_ENDPOINT` – optional summarization service URL.
 - `CONTENT_ENDPOINT` – endpoint for content extraction.
 - `ENTITIES_ENDPOINT` – endpoint for entity extraction.
-- `ROUTELLM_ENDPOINT` – LLM router URL.
+- `ROUTELLM_ENDPOINT` – optional URL for forwarding requests from the gateway's router Lambda to an external RouteLLM service.
 - `EMBED_MODEL` / `SBERT_MODEL` – embedding configuration.
 - `OPENAI_EMBED_MODEL` – OpenAI model name.
 - `COHERE_SECRET_NAME` – name or ARN of the Cohere API key secret.
@@ -65,7 +65,9 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `NVIDIA_SECRET_NAME` – name or ARN of the NVIDIA API key secret.
 - `VECTOR_SEARCH_CANDIDATES` – number of search results retrieved before re-ranking.
 
-### LLM Router and Invocation
+### LLM Gateway
+
+These settings configure the router and invocation Lambdas bundled with the gateway service.
 
 - `BEDROCK_OPENAI_ENDPOINTS` – comma‑separated Bedrock endpoints.
 - `BEDROCK_SECRET_NAME` – name or ARN of the Bedrock API key secret.

--- a/docs/event_schemas.md
+++ b/docs/event_schemas.md
@@ -49,7 +49,7 @@ The IDP Lambdas are triggered by standard S3 events. Each event contains a list 
 }
 ```
 
-## LLM Router/Invocation Payload
+## LLM Gateway Payload
 
 ```json
 {

--- a/docs/knowledge_rag_usage.md
+++ b/docs/knowledge_rag_usage.md
@@ -16,7 +16,7 @@ This guide covers recommended practices for ingesting documents into the knowled
 2. Specify the same `collection_name` used during ingestion so the search runs against the correct Milvus collection. Provide a `file_guid` to limit results to chunks from a single document.
 3. The query Lambda calls the summarization with context function from the `rag-retrieval` stack. Configure `VECTOR_SEARCH_FUNCTION` to `HybridSearchFunctionArn` for keyword filtering in addition to vector similarity.
 4. Enable the re-rank Lambda when higher quality ordering of results is required. Set `RERANK_FUNCTION` in the retrieval stack to the ARN of `rerank-lambda`.
-5. Summaries returned from `/kb/query` come from the LLM router. Adjust router settings as documented in [docs/router_configuration.md](router_configuration.md) to experiment with different models.
+5. Summaries returned from `/kb/query` come from the LLM Gateway. Adjust router settings as documented in [docs/router_configuration.md](router_configuration.md) to experiment with different models.
 
 ## Optimizing for Quality
 

--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -2,6 +2,8 @@
 
 The prompt engine built into the **llm-gateway** Lambda renders text templates stored in a DynamoDB table and forwards the result to the selected backend. Templates are addressed by a `prompt_id` and `version` so multiple revisions can be stored.
 
+The **llm-gateway** service combines what were previously three separate Lambdas—prompt engine, router and invocation—into a single stack.  Requests flow through these components in order so templates are expanded, routed and then executed against Bedrock or Ollama.
+
 ## DynamoDB Items
 
 Entries in the table include at minimum the following attributes:

--- a/docs/router_configuration.md
+++ b/docs/router_configuration.md
@@ -1,6 +1,6 @@
-# LLM Router Configuration
+# LLM Gateway Router Configuration
 
-This document details the environment variables used by the router Lambda and how they are typically provided.
+This document details the environment variables used by the router Lambda that forms part of the **llm-gateway** service and how they are typically provided.
 
 ## Environment Variables
 

--- a/docs/summarization_workflow.md
+++ b/docs/summarization_workflow.md
@@ -1,6 +1,6 @@
 # Summarization Step Function Workflow
 
-This document describes the multi-step AWS Step Functions state machine that orchestrates the summarization pipeline. The workflow ingests a document, runs a series of prompts in parallel, and generates a summary file that can be PDF, DOCX, JSON or XML, optionally merging PDF or DOCX output with the original document.
+This document describes the multi-step AWS Step Functions state machine that orchestrates the summarization pipeline. The workflow ingests a document, runs a series of prompts in parallel, and generates a summary file that can be PDF, DOCX, JSON or XML, optionally merging PDF or DOCX output with the original document.  Prompt execution is handled by the **llm-gateway** service which renders templates and forwards the requests to the chosen backend.
 
 ```mermaid
 stateDiagram-v2
@@ -93,9 +93,7 @@ Model parameters are provided under `body.llm_params`. To control the LLM's beha
 ### Using `workflow_id`
 
 Instead of a `prompts` array you can provide a `workflow_id` referencing a saved
-collection of prompts. The state machine will fetch the list from the Prompt
-
-Engine automatically and include the workflow's system prompt:
+collection of prompts. The state machine will fetch the list from the LLM Gateway's prompt engine automatically and include the workflow's system prompt:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- clarify that prompt engine is part of llm-gateway
- integrate llm-gateway into summarization workflow description
- rename router docs and environment variable section
- update references to the new gateway in other docs

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6869c2d57930832f8ff61ce519b10b51