### PR TITLE
Update RAG docs

### DIFF
--- a/docs/knowledge_rag_usage.md
+++ b/docs/knowledge_rag_usage.md
@@ -7,14 +7,14 @@ This guide covers recommended practices for ingesting documents into the knowled
 1. Use the `/kb/ingest` endpoint provided by the **knowledge-base** service or invoke the `ingest-lambda` function directly.
 2. Always include `collection_name` to specify the target Milvus collection where embeddings should be stored.
 3. Include optional metadata fields such as `department`, `team`, `user` and `entities` in your request. These values are stored with each chunk and can later be used to filter queries.
-4. Large files should be processed by the IDP pipeline first and then passed to the ingestion Step Function from `rag-ingestion`.
+4. Large files should be processed by the IDP pipeline first and then passed to the ingestion Step Function from `rag-stack`.
 5. Tune the chunk size and overlap through the `CHUNK_SIZE` and `CHUNK_OVERLAP` parameters in Parameter Store to balance retrieval accuracy and cost.
 
 ## Querying the Knowledge Base
 
 1. Use `/kb/query` to search the indexed documents. Provide natural language queries and optionally pass the same metadata fields (`department`, `team`, `user`, `entities`) to narrow results.
 2. Specify the same `collection_name` used during ingestion so the search runs against the correct Milvus collection. Provide a `file_guid` to limit results to chunks from a single document.
-3. The query Lambda calls the summarization with context function from the `rag-retrieval` stack. Configure `VECTOR_SEARCH_FUNCTION` to `HybridSearchFunctionArn` for keyword filtering in addition to vector similarity.
+3. The query Lambda calls the summarization with context function from the `rag-stack` stack. Configure `VECTOR_SEARCH_FUNCTION` to `HybridSearchFunctionArn` for keyword filtering in addition to vector similarity.
 4. Enable the re-rank Lambda when higher quality ordering of results is required. Set `RERANK_FUNCTION` in the retrieval stack to the ARN of `rerank-lambda`.
 5. Summaries returned from `/kb/query` come from the LLM Gateway. Adjust router settings as documented in [docs/router_configuration.md](router_configuration.md) to experiment with different models.
 

--- a/docs/rag_ingestion_workflow.md
+++ b/docs/rag_ingestion_workflow.md
@@ -1,8 +1,8 @@
 # RAG Ingestion Step Function Workflow
 
 This document describes the `IngestionStateMachine` defined in
-`services/rag-ingestion/template.yaml`. The workflow is typically started by the
-`rag-ingestion-worker` after the `file-ingestion` Step Function runs the IDP
+`services/rag-stack/template.yaml`. The workflow is typically started by the
+`rag-stack-worker` after the `file-ingestion` Step Function runs the IDP
 pipeline to extract text from an uploaded file and enqueues a message. New
 objects placed under `TextDocPrefix` in the configured S3 bucket can also
 trigger the workflow directly. The state machine splits the text into chunks,
@@ -90,7 +90,7 @@ embeddings and metadata to the Milvus insert step.
 Large ingestion jobs may be placed on an SQS queue instead of calling the state
 machine directly. This is normally done by the `file-ingestion` service after
 the IDP pipeline finishes extracting text from a document. The
-`rag-ingestion-worker` Lambda monitors the queue and starts
+`rag-stack-worker` Lambda monitors the queue and starts
 `IngestionStateMachine` for each message. Any failed messages are moved to
 `IngestionDLQ` and retried automatically. The queue URL is exported from the
 stack as `IngestionQueueUrl`.


### PR DESCRIPTION
## Summary
- update docs to refer to rag-stack service

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6869d32a615c832f97762c5a04c9a491