### PR TITLE
Fix proxy import paths

### DIFF
--- a/services/vector-db/src/__init__.py
+++ b/services/vector-db/src/__init__.py
@@ -1,0 +1,1 @@
+"""Vector DB service modules."""

--- a/services/vector-db/src/proxy/__init__.py
+++ b/services/vector-db/src/proxy/__init__.py
@@ -1,0 +1,1 @@
+"""Vector DB proxy package."""

--- a/services/vector-db/src/proxy/vector_db_proxy_lambda.py
+++ b/services/vector-db/src/proxy/vector_db_proxy_lambda.py
@@ -7,8 +7,8 @@ from typing import Any, Dict
 
 from common_utils import configure_logger
 
-from .. import milvus_handler_lambda as milvus_handler
-from .. import elastic_search_handler_lambda as es_handler
+import milvus_handler_lambda as milvus_handler
+import elastic_search_handler_lambda as es_handler
 
 logger = configure_logger(__name__)
 


### PR DESCRIPTION
## Summary
- convert relative imports in `vector_db_proxy_lambda.py` to absolute ones
- add package markers under vector-db service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869f49eec70832f90ee026fae38bb79