### PR TITLE
Make summary heading configurable

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1133,7 +1133,7 @@ def test_summary_lambda_forwards(monkeypatch):
     )
     captured = {}
 
-    def fake_create(summaries):
+    def fake_create(summaries, *args):
         captured["summaries"] = summaries
         return io.BytesIO(b"d")
 

--- a/tests/test_pdf_helpers.py
+++ b/tests/test_pdf_helpers.py
@@ -38,7 +38,7 @@ def test_add_title_page(config):
     from fpdf import FPDF
     pdf = FPDF(unit="mm", format="A4")
     pdf.set_margins(20, 20)
-    module._add_title_page(pdf, 10, 12)
+    module._add_title_page(pdf, 10, 12, "APS Summary")
     data = pdf.output(dest='S')
     text = PdfReader(io.BytesIO(data)).pages[0].extract_text()
     assert "APS Summary" in text


### PR DESCRIPTION
## Summary
- allow customizing the PDF heading and closing text via optional environment variables or request fields
- update PDF helper tests
- fix summary lambda tests for new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a0b7e62e0832f98e61f31bde04d2a