### PR TITLE
Allow custom headings in summary PDF

### DIFF
--- a/services/summarization/README.md
+++ b/services/summarization/README.md
@@ -112,6 +112,28 @@ An example prompt is available in
 The queue worker passes ``llm_params`` to the ``llm-gateway`` Lambda which
 forwards ``system_prompt`` to the selected backend.
 
+## Summary heading and closing text
+
+`file-summary-lambda` writes a heading at the start of the PDF and a closing line
+after the summaries. These default to ``"Summary"`` and ``"====End of Summary====``.
+Override them with ``SUMMARY_HEADING`` and ``SUMMARY_CLOSING_TEXT`` environment
+variables or include ``summary_heading`` and ``summary_closing_text`` in the
+workflow input.
+
+Sample APS values are stored in
+[`use-cases/aps-summarization/config/summary_labels.json`](../../use-cases/aps-summarization/config/summary_labels.json).
+Pass them when starting a workflow:
+
+```json
+{
+  "body": {
+    "workflow_id": "aps",
+    "collection_name": "my-collection",
+    "summary_heading": "APS Summary",
+    "summary_closing_text": "====End of APS Summary===="
+  }
+}
+```
 
 ## Local testing
 

--- a/services/summarization/src/file_summary_lambda.py
+++ b/services/summarization/src/file_summary_lambda.py
@@ -221,8 +221,8 @@ def _render_table(pdf: FPDF, table: List[List[str]]) -> None:
 
 def create_summary_pdf(
     summaries: List[str],
-    heading: str = "APS Summary",
-    closing_text: str = "====End of APS Summary====",
+    heading: str = "Summary",
+    closing_text: str = "====End of Summary====",
 ) -> BytesIO:
     """Build a summary PDF from a list of summary blocks."""
 
@@ -365,11 +365,11 @@ def process_for_summary(event: SummaryEvent, context: Any) -> Dict[str, Any]:
 
         heading = event_body.get(
             "summary_heading",
-            os.getenv("SUMMARY_HEADING", "APS Summary"),
+            os.getenv("SUMMARY_HEADING", "Summary"),
         )
         closing_text = event_body.get(
             "summary_closing_text",
-            os.getenv("SUMMARY_CLOSING_TEXT", "====End of APS Summary===="),
+            os.getenv("SUMMARY_CLOSING_TEXT", "====End of Summary===="),
         )
 
         fmt = str(event_body.get("output_format", "pdf")).lower()

--- a/use-cases/aps-summarization/config/summary_labels.json
+++ b/use-cases/aps-summarization/config/summary_labels.json
@@ -1,0 +1,4 @@
+{
+  "summary_heading": "APS Summary",
+  "summary_closing_text": "====End of APS Summary===="
+}


### PR DESCRIPTION
## Summary
- default summary heading is now `Summary` instead of `APS Summary`
- adjust environment variable fallbacks
- add APS sample labels
- document how to override heading and closing text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a1113bbc8832fb64ff54da0f780d0