### PR TITLE
Add file metadata to summarization workflow

### DIFF
--- a/services/summarization/models.py
+++ b/services/summarization/models.py
@@ -10,15 +10,23 @@ class SummaryEvent:
     organic_bucket: str
     organic_bucket_key: str
     collection_name: Optional[str] = None
+    file_guid: Optional[str] = None
+    document_id: Optional[str] = None
     summaries: Optional[List[Dict[str, Any]]] = None
     statusMessage: Optional[str] = None
-    output_format: str = "pdf"
     extra: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SummaryEvent":
         body = data.get("body", data)
-        required = {"statusCode", "organic_bucket", "organic_bucket_key", "collection_name"}
+        required = {
+            "statusCode",
+            "organic_bucket",
+            "organic_bucket_key",
+            "collection_name",
+            "file_guid",
+            "document_id",
+        }
         missing = [k for k in required if k not in body]
         if missing:
             raise ValueError(f"Missing required event keys: {', '.join(missing)}")
@@ -27,9 +35,10 @@ class SummaryEvent:
             "statusCode",
             "organic_bucket",
             "organic_bucket_key",
+            "file_guid",
+            "document_id",
             "summaries",
             "statusMessage",
-            "output_format",
         }
         extra = {k: v for k, v in body.items() if k not in keys}
         params = {k: body.get(k) for k in keys}

--- a/services/summarization/src/summarize_worker_lambda.py
+++ b/services/summarization/src/summarize_worker_lambda.py
@@ -47,6 +47,8 @@ def _process_record(record: Dict[str, Any]) -> None:
         "retrieve_params": body.get("retrieve_params"),
         "router_params": body.get("router_params"),
         "llm_params": body.get("llm_params"),
+        "file_guid": body.get("file_guid"),
+        "document_id": body.get("document_id"),
     }
     if PROMPT_ENGINE_ENDPOINT and body.get("prompt_id"):
         engine_payload = {"prompt_id": body.get("prompt_id")}
@@ -83,7 +85,15 @@ def _process_record(record: Dict[str, Any]) -> None:
         ).get("choices", [{}])[0].get("message", {}).get("content", "")
         sf_client.send_task_success(
             taskToken=token,
-            output=json.dumps({"summary": summary, "Title": body.get("Title")}),
+            output=json.dumps(
+                {
+                    "summary": summary,
+                    "Title": body.get("Title"),
+                    "file_guid": body.get("file_guid"),
+                    "document_id": body.get("document_id"),
+                    "collection_name": body.get("collection_name"),
+                }
+            ),
         )
     except (ClientError, BotoCoreError, json.JSONDecodeError) as exc:  # pragma: no cover - runtime issues
         logger.exception("Error processing summarization request")

--- a/services/summarization/template.yaml
+++ b/services/summarization/template.yaml
@@ -282,12 +282,17 @@ Resources:
                       router_params.$: $states.input.body.router_params
                       llm_params.$: $states.input.body.llm_params
                       collection_name.$: $states.input.body.collection_name
+                      file_guid.$: $states.input.body.file_guid
+                      document_id.$: $states.input.body.document_id
                   Next: add_title
                 add_title:
                   Type: Pass
                   Parameters:
                     Title.$: $.Title
                     content.$: $.summary
+                    file_guid.$: $.file_guid
+                    document_id.$: $.document_id
+                    collection_name.$: $.collection_name
                   End: true
             Next: file_summary
           file_summary:
@@ -296,7 +301,7 @@ Resources:
             Output: '{% $states.result.Payload %}'
             Arguments:
               FunctionName: !GetAtt FileSummaryLambdaFunction.Arn
-              Payload: '{% $merge([$states.input, {"summaries": $.run_prompts, "collection_name": $states.input.body.collection_name}]) %}'
+              Payload: '{% $merge([$states.input, {"summaries": $.run_prompts, "collection_name": $states.input.body.collection_name, "file_guid": $states.input.body.file_guid, "document_id": $states.input.body.document_id}]) %}'
             Retry:
               - ErrorEquals:
                   - States.TaskFailed

--- a/tests/test_summarization_models.py
+++ b/tests/test_summarization_models.py
@@ -18,7 +18,7 @@ def test_file_processing_event_no_collection():
 
 def test_summary_event_missing():
     with pytest.raises(ValueError):
-        SummaryEvent.from_dict({"collection_name": "c"})
+        SummaryEvent.from_dict({"collection_name": "c", "statusCode": 200})
 
 
 def test_processing_status_event_from_body():

--- a/tests/test_summarize_worker.py
+++ b/tests/test_summarize_worker.py
@@ -44,9 +44,30 @@ def test_worker_prompt_engine(monkeypatch):
     monkeypatch.setattr(sys.modules["httpx"], "post", fake_post)
 
     module = load_lambda("worker", "services/summarization/src/summarize_worker_lambda.py")
-    event = {"Records": [{"body": json.dumps({"token": "tok", "query": "q", "collection_name": "c", "Title": "T", "prompt_id": "p1", "variables": {"a": 1}})}]}
+    event = {
+        "Records": [
+            {
+                "body": json.dumps(
+                    {
+                        "token": "tok",
+                        "query": "q",
+                        "collection_name": "c",
+                        "file_guid": "g",
+                        "document_id": "d",
+                        "Title": "T",
+                        "prompt_id": "p1",
+                        "variables": {"a": 1},
+                    }
+                )
+            }
+        ]
+    }
     module.lambda_handler(event, {})
 
     assert posted == {"url": "http://engine", "json": {"prompt_id": "p1", "variables": {"a": 1}}}
     assert invoked["payload"]["collection_name"] == "c"
+    assert invoked["payload"]["file_guid"] == "g"
+    assert invoked["payload"]["document_id"] == "d"
     assert success["output"]["summary"] == "sum"
+    assert success["output"]["file_guid"] == "g"
+    assert success["output"]["document_id"] == "d"


### PR DESCRIPTION
## Summary
- pass file GUID and document ID through the summarization state machine
- include identifiers when queueing summaries and when aggregating results
- simplify summary aggregation to return JSON data
- update SummaryEvent model with new fields
- fix unit tests for updated payloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a17cc750c832f8602fb3bd4a9f10d