### PR TITLE
Remove unused table sizing vars

### DIFF
--- a/services/summarization/src/file_summary_lambda.py
+++ b/services/summarization/src/file_summary_lambda.py
@@ -131,9 +131,6 @@ def render_table(
         of the last cell, keeping the same y-coordinate.
     """
     pdf.set_xy(x, y)
-    cols = len(table[0])
-    col_w = total_width / cols
-    line_h = pdf.font_size*1.5
     # Header row
     prefix = get_environment_prefix()
     font_size = get_values_from_ssm(f"{prefix}/SUMMARY_PDF_FONT_SIZE")


### PR DESCRIPTION
## Summary
- clean up `render_table` in PDF generation
- remove unused column sizing variables

## Testing
- `pytest tests/test_pdf_helpers.py::test_render_table -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a208cc014832f974ad786d3128979