### PR TITLE
Add SummaryEvent dataclass and unit tests

### DIFF
--- a/services/summarization/models.py
+++ b/services/summarization/models.py
@@ -12,20 +12,16 @@ class SummaryEvent:
     file_guid: str
     document_id: str
     statusCode: int
-    organic_bucket: Optional[str] = None
-    organic_bucket_key: Optional[str] = None
-    summaries: Optional[List[Dict[str, Any]]] = None
+    organic_bucket: str
+    organic_bucket_key: str
+    summaries: List[Dict[str, Any]]
     output_format: Optional[str] = None
     extra: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SummaryEvent":
         body = data.get("body", data)
-        required = {"collection_name", "file_guid", "document_id"}
-        if not required.issubset(body):
-            missing = ", ".join(sorted(required - body.keys()))
-            raise ValueError(f"{missing} missing from event")
-        keys = {
+        required = {
             "collection_name",
             "file_guid",
             "document_id",
@@ -33,8 +29,11 @@ class SummaryEvent:
             "organic_bucket",
             "organic_bucket_key",
             "summaries",
-            "output_format",
         }
+        if not required.issubset(body):
+            missing = ", ".join(sorted(required - body.keys()))
+            raise ValueError(f"{missing} missing from event")
+        keys = required | {"output_format"}
         extra = {k: v for k, v in body.items() if k not in keys}
         params = {k: body.get(k) for k in keys}
         params["extra"] = extra

--- a/tests/test_summarization_models.py
+++ b/tests/test_summarization_models.py
@@ -21,6 +21,35 @@ def test_summary_event_missing():
         SummaryEvent.from_dict({"collection_name": "c", "statusCode": 200})
 
 
+def test_summary_event_roundtrip():
+    data = {
+        "collection_name": "c",
+        "file_guid": "g",
+        "document_id": "d",
+        "statusCode": 200,
+        "organic_bucket": "b",
+        "organic_bucket_key": "k",
+        "summaries": [{"t": 1}],
+        "foo": "bar",
+    }
+    evt = SummaryEvent.from_dict(data)
+    assert evt.collection_name == "c" and evt.extra["foo"] == "bar"
+    out = evt.to_dict()
+    assert out["foo"] == "bar" and out["organic_bucket_key"] == "k"
+
+
+def test_summary_event_missing_required():
+    with pytest.raises(ValueError):
+        SummaryEvent.from_dict({
+            "collection_name": "c",
+            "file_guid": "g",
+            "document_id": "d",
+            "organic_bucket": "b",
+            "organic_bucket_key": "k",
+            "summaries": [],
+        })
+
+
 def test_processing_status_event_from_body():
     data = {"body": {"document_id": "d", "foo": 1}}
     evt = ProcessingStatusEvent.from_dict(data)


### PR DESCRIPTION
## Summary
- implement `SummaryEvent` in summarization models with `from_dict`/`to_dict`
- test new event dataclass creation and validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8d80f54c832f831cce4bb9931f05