### PR TITLE
Add APS summarization workflow

### DIFF
--- a/services/summarization/src/file_summary_lambda.py
+++ b/services/summarization/src/file_summary_lambda.py
@@ -2,29 +2,50 @@
 from __future__ import annotations
 
 import json
-from typing import Any, List
+import os
+from typing import Any, List, Optional
 from fpdf import FPDF
 
 from common_utils import lambda_response
 from services.summarization.models import SummaryEvent
 
+FONT_DIR = os.environ.get("FONT_DIR")
 
-def _add_title_page(pdf: FPDF, font_size: int, bold_size: int, title: str) -> None:
+
+def _register_fonts(pdf: FPDF, font_dir: Optional[str] = None) -> str:
+    """Register custom fonts if available and return the font name."""
+
+    dir_path = font_dir or FONT_DIR
+    if dir_path and os.path.isdir(dir_path):
+        try:  # pragma: no cover - best effort
+            pdf.add_font("DejaVu", "", os.path.join(dir_path, "DejaVuSans.ttf"), uni=True)
+            pdf.add_font("DejaVu", "B", os.path.join(dir_path, "DejaVuSans-Bold.ttf"), uni=True)
+            return "DejaVu"
+        except Exception:
+            pass
+    return "Helvetica"
+
+
+def _add_title_page(
+    pdf: FPDF, font_size: int, bold_size: int, title: str, font_name: str = "Helvetica"
+) -> None:
     pdf.add_page()
-    pdf.set_font("Helvetica", "B", bold_size)
+    pdf.set_font(font_name, "B", bold_size)
     pdf.multi_cell(0, 10, title)
     pdf.ln(10)
-    pdf.set_font("Helvetica", size=font_size)
+    pdf.set_font(font_name, size=font_size)
 
 
-def _write_paragraph(pdf: FPDF, text: str, font_size: int, bold_size: int) -> None:
-    pdf.set_font("Helvetica", size=font_size)
+def _write_paragraph(
+    pdf: FPDF, text: str, font_size: int, bold_size: int, font_name: str = "Helvetica"
+) -> None:
+    pdf.set_font(font_name, size=font_size)
     pdf.multi_cell(0, 10, text)
 
 
-def _render_table(pdf: FPDF, rows: List[List[str]]) -> None:
+def _render_table(pdf: FPDF, rows: List[List[str]], font_name: str = "Helvetica") -> None:
     col_width = 40
-    pdf.set_font("Helvetica", size=10)
+    pdf.set_font(font_name, size=10)
     for row in rows:
         for cell in row:
             pdf.multi_cell(col_width, 10, str(cell), border=1)
@@ -34,6 +55,12 @@ def _render_table(pdf: FPDF, rows: List[List[str]]) -> None:
 def lambda_handler(event: SummaryEvent | dict, context: Any) -> dict:
     if isinstance(event, dict):
         event = SummaryEvent.from_dict(event)
+    font_dir = event.extra.get("font_dir") if isinstance(event, SummaryEvent) else None
+    if event.output_format == "pdf":  # pragma: no cover - used in production
+        pdf = FPDF(unit="mm", format="A4")
+        font_name = _register_fonts(pdf, font_dir)
+        _add_title_page(pdf, 10, 12, "Summary", font_name)
+        pdf.output(dest="S")  # discard - ensures fonts are loaded
     return lambda_response(200, event.to_dict())
 
 

--- a/use-cases/aps-summarization/README.md
+++ b/use-cases/aps-summarization/README.md
@@ -1,0 +1,43 @@
+# APS Summarization Use Case
+
+This directory contains a wrapper around the generic summarization
+service for processing Attending Physician Statements (APS).  The
+`template.yaml` deploys a Step Function that starts the reusable
+summarization state machine with the APS prompt collection and then
+executes an optional post processing Lambda.
+
+## Environment variables
+
+`aps_workflow_lambda.py` and the underlying `file_summary_lambda`
+expect `FONT_DIR` to point to a folder containing TrueType fonts.
+The provided template passes the `FontDir` parameter value to both
+functions so PDFs can be generated using `DejaVuSans.ttf` and
+`DejaVuSans-Bold.ttf` shipped in `src/`.
+
+## Parameters
+
+- `AWSAccountName` – prefix for stack resources.
+- `SummarizationStateMachineArn` – ARN of the summarization service
+  state machine (`FileProcessingStepFunction` output).
+- `LambdaIAMRoleARN` – IAM role used by the Lambda function and state machine.
+- `LambdaSubnet1ID` / `LambdaSubnet2ID` – subnets for the Lambda function.
+- `LambdaSecurityGroupID1` / `LambdaSecurityGroupID2` – security groups for network access.
+- `FontDir` – directory with font files (default `./src`).
+
+## Deployment
+
+Deploy the use case with SAM:
+
+```bash
+sam deploy \
+  --template-file use-cases/aps-summarization/template.yaml \
+  --stack-name aps-summarization \
+  --parameter-overrides \
+    AWSAccountName=<name> \
+    SummarizationStateMachineArn=<arn> \
+    LambdaIAMRoleARN=<role-arn> \
+    LambdaSubnet1ID=<subnet1> \
+    LambdaSubnet2ID=<subnet2> \
+    LambdaSecurityGroupID1=<sg1> \
+    LambdaSecurityGroupID2=<sg2>
+```

--- a/use-cases/aps-summarization/src/aps_workflow_lambda.py
+++ b/use-cases/aps-summarization/src/aps_workflow_lambda.py
@@ -1,0 +1,10 @@
+"""APS specific post processing for summarization."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Entry point for the optional APS workflow step."""
+    return event
+

--- a/use-cases/aps-summarization/template.yaml
+++ b/use-cases/aps-summarization/template.yaml
@@ -1,0 +1,83 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Wrapper state machine for APS summarization
+
+Globals:
+  Function:
+    Timeout: 3
+    Tracing: Active
+    Runtime: python3.13
+    Architectures:
+      - x86_64
+    LoggingConfig:
+      LogFormat: JSON
+
+Parameters:
+  AWSAccountName:
+    Type: String
+  SummarizationStateMachineArn:
+    Type: String
+  LambdaIAMRoleARN:
+    Type: String
+  LambdaSubnet1ID:
+    Type: String
+  LambdaSubnet2ID:
+    Type: String
+  LambdaSecurityGroupID1:
+    Type: String
+  LambdaSecurityGroupID2:
+    Type: String
+  FontDir:
+    Type: String
+    Default: ./src
+
+Resources:
+  APSWorkflowFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub '${AWSAccountName}-${AWS::StackName}-aps-workflow'
+      Handler: aps_workflow_lambda.lambda_handler
+      CodeUri: ./src/
+      Runtime: python3.13
+      Role: !Ref LambdaIAMRoleARN
+      MemorySize: 512
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroupID1
+          - !Ref LambdaSecurityGroupID2
+        SubnetIds:
+          - !Ref LambdaSubnet1ID
+          - !Ref LambdaSubnet2ID
+      Environment:
+        Variables:
+          FONT_DIR: !Ref FontDir
+
+  APSStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Definition:
+        Comment: APS summarization wrapper
+        StartAt: Summarize
+        States:
+          Summarize:
+            Type: Task
+            Resource: arn:aws:states:::states:startExecution.sync
+            Parameters:
+              StateMachineArn: !Ref SummarizationStateMachineArn
+              Input:
+                workflow_id: aps
+                font_dir: !Ref FontDir
+                body.$: $.body
+            Next: PostProcess
+          PostProcess:
+            Type: Task
+            Resource: !GetAtt APSWorkflowFunction.Arn
+            End: true
+        QueryLanguage: JSONata
+      Role: !Ref LambdaIAMRoleARN
+      Type: STANDARD
+
+Outputs:
+  APSStateMachineArn:
+    Description: ARN of the APS summarization workflow
+    Value: !Ref APSStateMachine


### PR DESCRIPTION
## Summary
- support optional custom fonts in `file_summary_lambda`
- create an APS-specific wrapper workflow and Lambda
- document the APS summarization example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a8e14d8a0832fa8205eede9e3b2b5