### PR TITLE
Update APS wrapper to use ZIP workflow

### DIFF
--- a/tests/test_aps_state_machine.py
+++ b/tests/test_aps_state_machine.py
@@ -1,0 +1,9 @@
+
+def test_aps_state_machine_definition():
+    with open('use-cases/aps-summarization/template.yaml') as fh:
+        content = fh.read()
+
+    assert 'StartAt: ProcessZip' in content
+    assert 'ProcessZip:' in content
+    assert 'PostProcess:' in content
+    assert 'ZipFileProcessingStepFunctionArn' in content

--- a/use-cases/aps-summarization/README.md
+++ b/use-cases/aps-summarization/README.md
@@ -2,9 +2,11 @@
 
 This directory contains a wrapper around the generic summarization
 service for processing Attending Physician Statements (APS).  The
-`template.yaml` deploys a Step Function that starts the reusable
-summarization state machine with the APS prompt collection and then
-executes an optional post processing Lambda.
+`template.yaml` deploys a Step Function that now launches the ZIP
+processing workflow which in turn extracts the archive, runs the
+summarization state machine for each PDF and finally assembles a new
+ZIP file.  After the archive is created the APS workflow invokes an
+optional post processing Lambda.
 
 ## Environment variables
 
@@ -27,6 +29,7 @@ SSM parameter name via the `labels_path` property on the workflow input.
 - `LambdaSecurityGroupID1` / `LambdaSecurityGroupID2` – security groups for network access.
 - `FontDir` – directory with font files (default `./src`).
 - `LabelsPath` – path or SSM name for `summary_labels.json` (default `./config/summary_labels.json`).
+- `ZipFileProcessingStepFunctionArn` – ARN of the ZIP processing state machine.
 
 The APS state machine forwards the `FontDir` and `LabelsPath` values as
 `font_dir` and `labels_path` properties when it starts the summarization
@@ -50,5 +53,6 @@ sam deploy \
     LambdaSecurityGroupID1=<sg1> \
     LambdaSecurityGroupID2=<sg2> \
     FontDir=<font_dir> \
-    LabelsPath=<labels_path>
+    LabelsPath=<labels_path> \
+    ZipFileProcessingStepFunctionArn=<arn>
 ```

--- a/use-cases/aps-summarization/template.yaml
+++ b/use-cases/aps-summarization/template.yaml
@@ -17,6 +17,8 @@ Parameters:
     Type: String
   SummarizationStateMachineArn:
     Type: String
+  ZipFileProcessingStepFunctionArn:
+    Type: String
   LambdaIAMRoleARN:
     Type: String
   LambdaSubnet1ID:
@@ -55,18 +57,31 @@ Resources:
         Variables:
           FONT_DIR: !Ref FontDir
 
+  ZipSFStartPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub '${AWSAccountName}-${AWS::StackName}-zip-sf-start'
+      Roles:
+        - !Select [1, !Split ['/', !Ref LambdaIAMRoleARN]]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: states:StartExecution
+            Resource: !Ref ZipFileProcessingStepFunctionArn
+
   APSStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
       Definition:
         Comment: APS summarization wrapper
-        StartAt: Summarize
+        StartAt: ProcessZip
         States:
-          Summarize:
+          ProcessZip:
             Type: Task
             Resource: arn:aws:states:::states:startExecution.sync
             Parameters:
-              StateMachineArn: !Ref SummarizationStateMachineArn
+              StateMachineArn: !Ref ZipFileProcessingStepFunctionArn
               Input:
                 workflow_id: aps
                 font_dir: !Ref FontDir


### PR DESCRIPTION
## Summary
- launch new zip-processing state machine from APS workflow
- document zip processing parameter and workflow
- add unit test for APS state machine definition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9c6e5e08832f8e108c2523d6a5e3