### PR TITLE
Refactor summarization workflow

### DIFF
--- a/docs/summarization_workflow.md
+++ b/docs/summarization_workflow.md
@@ -1,15 +1,13 @@
 # Summarization Step Function Workflow
 
-This document describes the multi-step AWS Step Functions state machine that orchestrates the summarization pipeline. The workflow ingests a document, runs a series of prompts in parallel, and generates a summary file that can be PDF, DOCX, JSON or XML, optionally merging PDF or DOCX output with the original document.
+This document describes the Step Functions that orchestrate the summarization pipeline. `FileProcessingStepFunction` runs the file ingestion workflow and then launches a dedicated `SummarizationWorkflow`. The latter loads prompts, runs them in parallel and returns a summary file that can be PDF, DOCX, JSON or XML. The processing state machine can optionally merge PDF or DOCX output with the original document.
 
 ```mermaid
 stateDiagram-v2
-    file_ingestion --> check_workflow
     check_workflow --> load_prompts
     load_prompts --> run_prompts_map
     state "run_prompts (Map)" as run_prompts_map
     run_prompts_map --> file_summary
-    file_summary --> file_assemble
 ```
 
 ## Map State

--- a/services/summarization/README.md
+++ b/services/summarization/README.md
@@ -1,12 +1,13 @@
 # Summarization Service
 
-This service orchestrates document processing and summarization. The Step
-Function defined in `template.yaml` begins by invoking the
-`FileIngestionStateMachine` from the **file-ingestion** stack. Once the uploaded
-file has been prepared, the workflow runs the prompts, generates summaries and
-merges them with the original PDF using the **file-assembly** service. The same
-state machine is also triggered from the **knowledge-base** ingestion pipeline
-when uploading new documents.
+This service orchestrates document processing and summarization. The stack now
+provisions two Step Functions. `FileProcessingStepFunction` calls the
+`FileIngestionStateMachine` from the **file-ingestion** stack and then starts a
+separate `SummarizationWorkflow` which loads prompts and generates the summary
+file. When configured, the workflow merges the summary with the original PDF
+using the **file-assembly** service. The same processing state machine is also
+triggered from the **knowledge-base** ingestion pipeline when uploading new
+documents.
 
 Details of the state machine, including the parallel `run_prompts` map state, are documented in [docs/summarization_workflow.md](../../docs/summarization_workflow.md).
 

--- a/services/summarization/template.yaml
+++ b/services/summarization/template.yaml
@@ -197,7 +197,7 @@ Resources:
             Action:
               - states:SendTaskSuccess
               - states:SendTaskFailure
-            Resource: !Ref FileProcessingStepFunction
+            Resource: !Ref SummarizationWorkflow
 
   FileIngestionSFInvokePolicy:
     Type: AWS::IAM::Policy
@@ -213,6 +213,20 @@ Resources:
               - states:StartExecution
             Resource: !Ref FileIngestionStateMachineArn
 
+  SummarizationSFInvokePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub '${AWSAccountName}-${AWS::StackName}-summarization-sf-invoke'
+      Roles:
+        - !Select [1, !Split ['/', !Ref FileProcessingStepFunctionIAMRole]]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - states:StartExecution
+            Resource: !Ref SummarizationWorkflow
+
   StepFunctionSQSPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -225,6 +239,22 @@ Resources:
           - Effect: Allow
             Action: sqs:SendMessage
             Resource: !GetAtt SummaryQueue.Arn
+
+  SummarizationWorkflow:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: workflow/summarization.asl.json
+      DefinitionSubstitutions:
+        SummaryQueueUrl: !Ref SummaryQueue
+        LoadPromptsFunctionArn: !GetAtt LoadPromptsFunction.Arn
+        FileSummaryLambdaFunctionArn: !GetAtt FileSummaryLambdaFunction.Arn
+        RunPromptsConcurrency: !Ref RunPromptsConcurrency
+      Name: !Sub '${AWSAccountName}-${AWS::StackName}-summarization-sf'
+      Type: STANDARD
+      Role: !Ref FileProcessingStepFunctionIAMRole
+      Logging:
+        Level: 'OFF'
+        IncludeExecutionData: false
 
   FileProcessingStepFunction:
     Type: AWS::Serverless::StateMachine
@@ -240,74 +270,13 @@ Resources:
             Parameters:
               StateMachineArn: !Ref FileIngestionStateMachineArn
               Input: '{% $states.input %}'
-            Next: check_workflow
-          check_workflow:
-            Type: Choice
-            Choices:
-              - Variable: $.body.workflow_id
-                IsPresent: true
-                Next: load_prompts
-            Default: run_prompts
-          load_prompts:
+            Next: summarization_workflow
+          summarization_workflow:
             Type: Task
-            Resource: arn:aws:states:::lambda:invoke
-
-            Output: '{% $merge([$states.input.body, $states.result.Payload]) %}'
-            Arguments:
-              FunctionName: !GetAtt LoadPromptsFunction.Arn
-              Payload: '{% {"workflow_id": $states.input.body.workflow_id} %}'
-            ResultPath: $.body
-
-            Next: run_prompts
-          run_prompts:
-            Type: Map
-            ItemsPath: $.body.prompts
-            ResultPath: $.run_prompts
-            MaxConcurrency: !Ref RunPromptsConcurrency
-            Iterator:
-              StartAt: summarize
-              States:
-                summarize:
-                  Type: Task
-                  Resource: arn:aws:states:::sqs:sendMessage.waitForTaskToken
-                  Parameters:
-                    QueueUrl: !Ref SummaryQueue
-                    MessageBody:
-                      token.$: $$.Task.Token
-                      query.$: $$Map.Item.Value.query
-                      Title.$: $$Map.Item.Value.Title
-                      prompt_id.$: $$Map.Item.Value.prompt_id
-                      variables.$: $$Map.Item.Value.variables
-                      retrieve_params.$: $states.input.body.retrieve_params
-                      router_params.$: $states.input.body.router_params
-                      llm_params.$: $states.input.body.llm_params
-                      collection_name.$: $states.input.body.collection_name
-                  Next: add_title
-                add_title:
-                  Type: Pass
-                  Parameters:
-                    Title.$: $.Title
-                    content.$: $.summary
-                  End: true
-            Next: file_summary
-          file_summary:
-            Type: Task
-            Resource: arn:aws:states:::lambda:invoke
-            Output: '{% $states.result.Payload %}'
-            Arguments:
-              FunctionName: !GetAtt FileSummaryLambdaFunction.Arn
-              Payload: '{% $merge([$states.input, {"summaries": $.run_prompts, "collection_name": $states.input.body.collection_name}]) %}'
-            Retry:
-              - ErrorEquals:
-                  - States.TaskFailed
-                  - Lambda.ServiceException
-                  - Lambda.AWSLambdaException
-                  - Lambda.SdkClientException
-                  - Lambda.TooManyRequestsException
-                IntervalSeconds: 1
-                MaxAttempts: 3
-                BackoffRate: 2
-                JitterStrategy: FULL
+            Resource: arn:aws:states:::states:startExecution.sync
+            Parameters:
+              StateMachineArn: !Ref SummarizationWorkflow
+              Input.$: $
             Next: file_assemble
           file_assemble:
             Type: Task
@@ -340,6 +309,9 @@ Outputs:
   FileProcessingStepFunctionArn:
     Description: ARN of the file processing state machine
     Value: !Ref FileProcessingStepFunction
+  SummarizationWorkflowArn:
+    Description: ARN of the summarization state machine
+    Value: !Ref SummarizationWorkflow
   SummaryQueueUrl:
     Description: URL of the summarization queue
     Value: !Ref SummaryQueue

--- a/services/summarization/workflow/summarization.asl.json
+++ b/services/summarization/workflow/summarization.asl.json
@@ -1,0 +1,94 @@
+{
+  "Comment": "Process prompts and generate summaries",
+  "StartAt": "check_workflow",
+  "States": {
+    "check_workflow": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.body.workflow_id",
+          "IsPresent": true,
+          "Next": "load_prompts"
+        }
+      ],
+      "Default": "run_prompts"
+    },
+    "load_prompts": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": "{% $merge([$states.input.body, $states.result.Payload]) %}",
+      "Arguments": {
+        "FunctionName": "${LoadPromptsFunctionArn}",
+        "Payload": "{% {\"workflow_id\": $states.input.body.workflow_id} %}"
+      },
+      "ResultPath": "$.body",
+      "Next": "run_prompts"
+    },
+    "run_prompts": {
+      "Type": "Map",
+      "ItemsPath": "$.body.prompts",
+      "ResultPath": "$.run_prompts",
+      "MaxConcurrency": ${RunPromptsConcurrency},
+      "Iterator": {
+        "StartAt": "summarize",
+        "States": {
+          "summarize": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+            "Parameters": {
+              "QueueUrl": "${SummaryQueueUrl}",
+              "MessageBody": {
+                "token.$": "$$.Task.Token",
+                "query.$": "$$Map.Item.Value.query",
+                "Title.$": "$$Map.Item.Value.Title",
+                "prompt_id.$": "$$Map.Item.Value.prompt_id",
+                "variables.$": "$$Map.Item.Value.variables",
+                "retrieve_params.$": "$states.input.body.retrieve_params",
+                "router_params.$": "$states.input.body.router_params",
+                "llm_params.$": "$states.input.body.llm_params",
+                "collection_name.$": "$states.input.body.collection_name"
+              }
+            },
+            "Next": "add_title"
+          },
+          "add_title": {
+            "Type": "Pass",
+            "Parameters": {
+              "Title.$": "$.Title",
+              "content.$": "$.summary"
+            },
+            "End": true
+          }
+        }
+      },
+      "Next": "file_summary"
+    },
+    "file_summary": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": "{% $states.result.Payload %}",
+      "Arguments": {
+        "FunctionName": "${FileSummaryLambdaFunctionArn}",
+        "Payload": "{% $merge([$states.input, {\"summaries\": $.run_prompts, \"collection_name\": $states.input.body.collection_name}]) %}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.TaskFailed",
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "End": true
+    }
+    }
+  },
+  "QueryLanguage": "JSONata"
+}


### PR DESCRIPTION
## Summary
- move summarization logic to a new SummarizationWorkflow state machine
- update FileProcessingStepFunction to invoke the new workflow
- expose SummarizationWorkflow ARN from the stack
- document the updated workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa262bb8c832fba04821613bfa886