### PR TITLE
Add SummarizationWorkflow state machine

### DIFF
--- a/docs/summarization_workflow.md
+++ b/docs/summarization_workflow.md
@@ -19,13 +19,16 @@ stateDiagram-v2
 ```
 
 1. **ExtractZip** reads the uploaded archive from S3 and returns the S3 keys of the contained PDFs.
-2. **ProcessAllPdfs** maps each extracted file through the per‑file `FileProcessingStepFunction` from the **summarization** service.
+2. **ProcessAllPdfs** maps each extracted file through the per‑file
+   `FileProcessingStepFunction` from the **summarization** service. This workflow
+   runs the file-ingestion service and then invokes `SummarizationWorkflow`.
 3. **AssembleZip** collects each generated summary PDF and writes the final ZIP to S3.
 4. **SendToSNS** notifies stakeholders when any file fails.
 
 ## Per‑file Step Function
 
-`FileProcessingStepFunction` orchestrates IDP extraction, prompt loading and summarization for a single PDF.
+The per‑file workflow orchestrates IDP extraction and then invokes
+`SummarizationWorkflow` to generate the summary.
 
 ```mermaid
 stateDiagram-v2
@@ -44,7 +47,7 @@ stateDiagram-v2
 2. **LoadPrompts** calls `load-prompts-lambda` to fetch templates from the prompt engine. The Lambda posts the `workflow_id` received in the input to the gateway endpoint and returns the prompts along with a system prompt.
 3. **Summaries** iterates over the prompts and sends each one to `summarize-worker-lambda`.
 4. The worker Lambda invokes the retrieval Lambda from **rag-stack**. This queries the Milvus vector database via **vector-db** and forwards the assembled context to the LLM gateway for summarization.
-5. **FileSummary** assembles the results (typically PDF or DOCX) using `file-summary-lambda`. The summary document is uploaded to S3 and the Step Function output conforms to the schema in [event_schemas.md](event_schemas.md#summarization-event).
+5. **FileSummary** assembles the results (typically PDF or DOCX) using `summary-document-lambda`. The summary document is uploaded to S3 and the Step Function output conforms to the schema in [event_schemas.md](event_schemas.md#summarization-event).
 
 The initial input for the state machine must match the [Summarization Workflow Input](event_schemas.md#summarization-workflow-input). The output from each worker conforms to [RAG Summarization Payload](event_schemas.md#rag-summarization-payload).
 
@@ -60,7 +63,7 @@ aws dynamodb put-item \
 
 `system_prompt.json` contains the default system prompt referenced by `SYSTEM_WORKFLOW_ID` in `load-prompts-lambda`. Additional labels such as section headings are provided in `summary_labels.json` for use when generating the final document.
 
-`file-summary-lambda` automatically looks for `summary_labels.json` inside the
+`summary-document-lambda` automatically looks for `summary_labels.json` inside the
 directory defined by the `FONT_DIR` environment variable.  A different location
 or an SSM parameter name can be supplied via the `labels_path` property in the
 workflow input.  The APS wrapper forwards both `font_dir` and `labels_path`

--- a/services/summarization/README.md
+++ b/services/summarization/README.md
@@ -9,11 +9,19 @@ assembled into a summary document.
   the prompt engine.
 - **summarize-worker-lambda** – `src/summarize_worker_lambda.py` calls the
   summarization Lambda and reports results back to the state machine.
-- **file-summary-lambda** – `src/file_summary_lambda.py` creates the final
-  document. Helper functions are exposed for PDF generation.
+- **summary-document-lambda** – `src/file_summary_lambda.py` assembles the
+  final summary document. Helper functions are exposed for PDF generation.
 
-The `template.yaml` defines the SQS queue, Lambda functions and the
-`FileProcessingStepFunction` that ties them together.
+The `template.yaml` defines the SQS queue, Lambda functions and two Step
+Functions.
+
+* **SummarizationWorkflow** – starts at `LoadPrompts` and runs the summarization
+  tasks.
+* **FileProcessingStepFunction** – invokes the file-ingestion workflow and then
+  calls `SummarizationWorkflow` to generate the summary.
+
+Both state machine ARNs are exported as `FileProcessingStepFunctionArn` and
+`SummarizationWorkflowArn` for use by other stacks.
 
 ## Local testing
 

--- a/services/summarization/template.yaml
+++ b/services/summarization/template.yaml
@@ -107,10 +107,10 @@ Resources:
           PROMPT_ENGINE_ENDPOINT: !Ref PromptEngineEndpoint
           RAG_SUMMARY_FUNCTION_ARN: !Ref RAGSummaryFunctionArn
 
-  FileSummaryFunction:
+  SummaryDocumentFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub '${AWSAccountName}-${AWS::StackName}-file-summary'
+      FunctionName: !Sub '${AWSAccountName}-${AWS::StackName}-summary-document'
       Handler: file_summary_lambda.lambda_handler
       CodeUri: ./src/
       Runtime: python3.13
@@ -129,20 +129,13 @@ Resources:
         Variables:
           FILE_ASSEMBLE_FUNCTION: !Ref FileAssembleFunctionArn
 
-  FileProcessingStepFunction:
+  SummarizationWorkflow:
     Type: AWS::Serverless::StateMachine
     Properties:
       Definition:
-        Comment: Simple summarization workflow
-        StartAt: IDP
+        Comment: Summarization workflow
+        StartAt: LoadPrompts
         States:
-          IDP:
-            Type: Task
-            Resource: arn:aws:states:::states:startExecution.sync
-            Parameters:
-              StateMachineArn: !Ref FileIngestionStateMachineArn
-              Input.$: $
-            Next: LoadPrompts
           LoadPrompts:
             Type: Task
             Resource: !GetAtt LoadPromptsFunction.Arn
@@ -171,16 +164,45 @@ Resources:
             Next: FileSummary
           FileSummary:
             Type: Task
-            Resource: !GetAtt FileSummaryFunction.Arn
+            Resource: !GetAtt SummaryDocumentFunction.Arn
             End: true
         QueryLanguage: JSONata
       Role: !Ref LambdaIAMRoleARN
       Type: STANDARD
 
+  FileProcessingStepFunction:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Definition:
+        Comment: File ingestion then summarization
+        StartAt: IDP
+        States:
+          IDP:
+            Type: Task
+            Resource: arn:aws:states:::states:startExecution.sync
+            Parameters:
+              StateMachineArn: !Ref FileIngestionStateMachineArn
+              Input.$: $
+            Next: InvokeSummarizationWorkflow
+          InvokeSummarizationWorkflow:
+            Type: Task
+            Resource: arn:aws:states:::states:startExecution.sync
+            Parameters:
+              StateMachineArn: !Ref SummarizationWorkflow
+              Input.$: $
+            End: true
+        QueryLanguage: JSONata
+      Role: !Ref LambdaIAMRoleARN
+      Type: STANDARD
+
+
 Outputs:
   FileProcessingStepFunctionArn:
-    Description: ARN of the summarization state machine
+    Description: ARN of the file processing state machine
     Value: !Ref FileProcessingStepFunction
+  SummarizationWorkflowArn:
+    Description: ARN of the summarization workflow state machine
+    Value: !Ref SummarizationWorkflow
   SummaryQueueUrl:
     Description: URL of the summary SQS queue
     Value: !Ref SummaryQueue

--- a/tests/test_summarization_state_machine.py
+++ b/tests/test_summarization_state_machine.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+def test_summarization_template_contains_both_workflows():
+    content = Path('services/summarization/template.yaml').read_text()
+    assert 'SummarizationWorkflow:' in content
+    assert 'FileProcessingStepFunction:' in content
+    assert 'InvokeSummarizationWorkflow' in content
+    assert 'SummarizationWorkflowArn' in content
+    assert 'FileProcessingStepFunctionArn' in content

--- a/use-cases/aps-summarization/README.md
+++ b/use-cases/aps-summarization/README.md
@@ -19,13 +19,17 @@ stateDiagram-v2
 ```
 
 1. **ExtractZip** reads the uploaded archive from S3 and returns the S3 keys of the contained PDFs.
-2. **ProcessAllPdfs** maps each extracted file through the per‑file `FileProcessingStepFunction` from the **summarization** service.
+2. **ProcessAllPdfs** maps each extracted file through the
+   `FileProcessingStepFunction` from the **summarization** service. This
+   workflow runs the file-ingestion service and then invokes
+   `SummarizationWorkflow`.
 3. **AssembleZip** collects each generated summary PDF and writes the final ZIP to S3.
 4. **SendToSNS** notifies stakeholders when any file fails.
 
 ## Per‑file Step Function
 
-`FileProcessingStepFunction` orchestrates IDP extraction, prompt loading and summarization for a single PDF.
+This per‑file workflow orchestrates IDP extraction and then calls
+`SummarizationWorkflow` to generate the final summary.
 
 ```mermaid
 stateDiagram-v2
@@ -44,7 +48,7 @@ stateDiagram-v2
 2. **LoadPrompts** calls `load-prompts-lambda` to fetch templates from the prompt engine. The Lambda posts the `workflow_id` received in the input to the gateway endpoint and returns the prompts along with a system prompt.
 3. **Summaries** iterates over the prompts and sends each one to `summarize-worker-lambda`.
 4. The worker Lambda invokes the retrieval Lambda from **rag-stack**. This queries the Milvus vector database via **vector-db** and forwards the assembled context to the LLM gateway for summarization.
-5. **FileSummary** assembles the results (typically PDF or DOCX) using `file-summary-lambda`. The summary document is uploaded to S3 and the Step Function output conforms to the schema in [event_schemas.md](../../docs/event_schemas.md#summarization-event).
+5. **FileSummary** assembles the results (typically PDF or DOCX) using `summary-document-lambda`. The summary document is uploaded to S3 and the Step Function output conforms to the schema in [event_schemas.md](../../docs/event_schemas.md#summarization-event).
 
 The initial input for the state machine must match the [Summarization Workflow Input](../../docs/event_schemas.md#summarization-workflow-input). The output from each worker conforms to [RAG Summarization Payload](../../docs/event_schemas.md#rag-summarization-payload).
 
@@ -60,7 +64,7 @@ aws dynamodb put-item \
 
 `system_prompt.json` contains the default system prompt referenced by `SYSTEM_WORKFLOW_ID` in `load-prompts-lambda`. Additional labels such as section headings are provided in `summary_labels.json` for use when generating the final document.
 
-`file-summary-lambda` automatically looks for `summary_labels.json` inside the
+`summary-document-lambda` automatically looks for `summary_labels.json` inside the
 directory defined by the `FONT_DIR` environment variable.  A different location
 or an SSM parameter name can be supplied via the `labels_path` property in the
 workflow input.  The APS wrapper forwards both `font_dir` and `labels_path`
@@ -91,8 +95,8 @@ SSM parameter name via the `labels_path` property on the workflow input.
 ## Parameters
 
 - `AWSAccountName` – prefix for stack resources.
-- `SummarizationStateMachineArn` – ARN of the summarization service
-  state machine (`FileProcessingStepFunction` output).
+- `SummarizationStateMachineArn` – ARN of the summarization workflow from the
+  summarization service.
 - `LambdaIAMRoleARN` – IAM role used by the Lambda function and state machine.
 - `LambdaSubnet1ID` / `LambdaSubnet2ID` – subnets for the Lambda function.
 - `LambdaSecurityGroupID1` / `LambdaSecurityGroupID2` – security groups for network access.


### PR DESCRIPTION
## Summary
- add SummarizationWorkflow state machine for reusing summarization logic
- invoke SummarizationWorkflow from FileProcessingStepFunction
- export both state machine ARNs from the stack
- document both workflows and rename summary-document lambda
- test the presence of both state machines in the template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa6c56bc8832f98686a2810a5f60c