### PR TITLE
Document output_format in summarization README

### DIFF
--- a/services/summarization/README.md
+++ b/services/summarization/README.md
@@ -18,6 +18,12 @@ Function.
 * **SummarizationWorkflow** – starts at `LoadPrompts` and runs the summarization
   tasks. Messages posted to `SummaryQueue` trigger this workflow.
 
+The payload passed to `file-summary-lambda` may include an optional
+`output_format` field which determines the format of the summary file.
+Accepted values are `pdf`, `docx`, `json` and `xml`. When omitted the service
+produces a PDF. The full schema is documented in
+[`docs/event_schemas.md`](../../docs/event_schemas.md#summarization-event).
+
 The state machine ARN is exported as `SummarizationWorkflowArn` for use by other
 stacks.
 


### PR DESCRIPTION
## Summary
- document the optional `output_format` field for summarization
- explain allowed values and default behaviour
- point to the full Summarization Event schema for details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab7a4a644832fae78998f9049a305