### PR TITLE
Add router-layer requirements

### DIFF
--- a/common/layers/router-layer/requirements.txt
+++ b/common/layers/router-layer/requirements.txt
@@ -1,0 +1,3 @@
+httpx==0.28.1
+boto3==1.35.53
+langdetect==1.0.9


### PR DESCRIPTION
## Summary
- add `common/layers/router-layer/requirements.txt` with httpx, boto3 and langdetect
- layer dependencies are installed automatically in Dockerfiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b256e1b28832faa1f1bd77700ab81