### PR TITLE
Parameterise S3 prefixes

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -7,6 +7,12 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `AWS_ACCOUNT_NAME` – scopes stack resources for the file‑assembly, zip‑processing and summarization stacks.
 - `SSM_CACHE_TABLE` – DynamoDB table used by the SSM caching layer.
 
+### ZIP Processing
+
+- `RAW_PREFIX` – incoming ZIP folder for extracted files.
+- `EXTRACTED_PREFIX` – location where archives are unpacked.
+- `CURATED_PREFIX` – path for the final assembled ZIPs.
+
 ### Intelligent Document Processing (IDP)
 
 - `BUCKET_NAME` – S3 bucket for pipeline objects.

--- a/services/idp/src/classifier_lambda.py
+++ b/services/idp/src/classifier_lambda.py
@@ -93,9 +93,9 @@ def _handle_record(record: dict) -> None:
     bucket = record.get("s3", {}).get("bucket", {}).get("name")
     key = record.get("s3", {}).get("object", {}).get("key")
     bucket_name = get_config("BUCKET_NAME", bucket, key)
-    raw_prefix = get_config("RAW_PREFIX", bucket, key) or ""
-    office_prefix = get_config("OFFICE_PREFIX", bucket, key) or "office-docs/"
-    pdf_raw_prefix = get_config("PDF_RAW_PREFIX", bucket, key) or "pdf-raw/"
+    raw_prefix = get_config("RAW_PREFIX", bucket, key) or os.environ.get("RAW_PREFIX", "")
+    office_prefix = get_config("OFFICE_PREFIX", bucket, key) or os.environ.get("OFFICE_PREFIX")
+    pdf_raw_prefix = get_config("PDF_RAW_PREFIX", bucket, key) or os.environ.get("PDF_RAW_PREFIX")
     if raw_prefix and not raw_prefix.endswith("/"):
         raw_prefix += "/"
     if office_prefix and not office_prefix.endswith("/"):

--- a/services/idp/src/combine_lambda.py
+++ b/services/idp/src/combine_lambda.py
@@ -151,9 +151,9 @@ def _handle_record(record: dict) -> None:
     bucket = record.get("s3", {}).get("bucket", {}).get("name")
     key = record.get("s3", {}).get("object", {}).get("key")
     bucket_name = get_config("BUCKET_NAME", bucket, key)
-    pdf_page_prefix = get_config("PDF_PAGE_PREFIX", bucket, key) or "pdf-pages/"
-    text_page_prefix = get_config("TEXT_PAGE_PREFIX", bucket, key) or "text-pages/"
-    text_doc_prefix = get_config("TEXT_DOC_PREFIX", bucket, key) or "text-docs/"
+    pdf_page_prefix = get_config("PDF_PAGE_PREFIX", bucket, key) or os.environ.get("PDF_PAGE_PREFIX")
+    text_page_prefix = get_config("TEXT_PAGE_PREFIX", bucket, key) or os.environ.get("TEXT_PAGE_PREFIX")
+    text_doc_prefix = get_config("TEXT_DOC_PREFIX", bucket, key) or os.environ.get("TEXT_DOC_PREFIX")
     if pdf_page_prefix and not pdf_page_prefix.endswith("/"):
         pdf_page_prefix += "/"
     if text_page_prefix and not text_page_prefix.endswith("/"):

--- a/services/idp/src/office_extractor_lambda.py
+++ b/services/idp/src/office_extractor_lambda.py
@@ -79,8 +79,8 @@ def _process_record(record: dict, document_id: str | None = None) -> None:
     bucket = record.get("s3", {}).get("bucket", {}).get("name")
     key = record.get("s3", {}).get("object", {}).get("key")
     bucket_name = get_config("BUCKET_NAME", bucket, key)
-    office_prefix = get_config("OFFICE_PREFIX", bucket, key) or ""
-    text_doc_prefix = get_config("TEXT_DOC_PREFIX", bucket, key) or "text-docs/"
+    office_prefix = get_config("OFFICE_PREFIX", bucket, key) or os.environ.get("OFFICE_PREFIX", "")
+    text_doc_prefix = get_config("TEXT_DOC_PREFIX", bucket, key) or os.environ.get("TEXT_DOC_PREFIX")
     if office_prefix and not office_prefix.endswith("/"):
         office_prefix += "/"
     if text_doc_prefix and not text_doc_prefix.endswith("/"):

--- a/services/idp/src/output_lambda.py
+++ b/services/idp/src/output_lambda.py
@@ -74,7 +74,7 @@ def _handle_record(record: dict) -> None:
     bucket = record.get("s3", {}).get("bucket", {}).get("name")
     key = record.get("s3", {}).get("object", {}).get("key")
     bucket_name = get_config("BUCKET_NAME", bucket, key)
-    text_doc_prefix = get_config("TEXT_DOC_PREFIX", bucket, key) or "text-docs/"
+    text_doc_prefix = get_config("TEXT_DOC_PREFIX", bucket, key) or os.environ.get("TEXT_DOC_PREFIX")
     api_url = get_config("EDI_SEARCH_API_URL", bucket, key)
     api_key = get_config("EDI_SEARCH_API_KEY", bucket, key)
     if text_doc_prefix and not text_doc_prefix.endswith("/"):

--- a/services/idp/src/pdf_ocr_extractor_lambda.py
+++ b/services/idp/src/pdf_ocr_extractor_lambda.py
@@ -118,8 +118,8 @@ def _handle_record(record: dict) -> None:
     bucket = record.get("s3", {}).get("bucket", {}).get("name")
     key = record.get("s3", {}).get("object", {}).get("key")
     bucket_name = get_config("BUCKET_NAME", bucket, key)
-    pdf_scan_page_prefix = get_config("PDF_SCAN_PAGE_PREFIX", bucket, key) or "scan-pages/"
-    text_page_prefix = get_config("TEXT_PAGE_PREFIX", bucket, key) or "text-pages/"
+    pdf_scan_page_prefix = get_config("PDF_SCAN_PAGE_PREFIX", bucket, key) or os.environ.get("PDF_SCAN_PAGE_PREFIX")
+    text_page_prefix = get_config("TEXT_PAGE_PREFIX", bucket, key) or os.environ.get("TEXT_PAGE_PREFIX")
     dpi = int(get_config("DPI", bucket, key) or "300")
     engine = (get_config("OCR_ENGINE", bucket, key) or "easyocr").lower()
     trocr_endpoint = get_config("TROCR_ENDPOINT", bucket, key)

--- a/services/idp/src/pdf_page_classifier_lambda.py
+++ b/services/idp/src/pdf_page_classifier_lambda.py
@@ -79,9 +79,9 @@ def _handle_record(record: dict) -> None:
     bucket = record.get("s3", {}).get("bucket", {}).get("name")
     key = record.get("s3", {}).get("object", {}).get("key")
     bucket_name = get_config("BUCKET_NAME", bucket, key)
-    pdf_page_prefix = get_config("PDF_PAGE_PREFIX", bucket, key) or ""
-    pdf_text_page_prefix = get_config("PDF_TEXT_PAGE_PREFIX", bucket, key) or "text-pages/"
-    pdf_scan_page_prefix = get_config("PDF_SCAN_PAGE_PREFIX", bucket, key) or "scan-pages/"
+    pdf_page_prefix = get_config("PDF_PAGE_PREFIX", bucket, key) or os.environ.get("PDF_PAGE_PREFIX", "")
+    pdf_text_page_prefix = get_config("PDF_TEXT_PAGE_PREFIX", bucket, key) or os.environ.get("PDF_TEXT_PAGE_PREFIX")
+    pdf_scan_page_prefix = get_config("PDF_SCAN_PAGE_PREFIX", bucket, key) or os.environ.get("PDF_SCAN_PAGE_PREFIX")
     if pdf_page_prefix and not pdf_page_prefix.endswith("/"):
         pdf_page_prefix += "/"
     if pdf_text_page_prefix and not pdf_text_page_prefix.endswith("/"):

--- a/services/idp/src/pdf_split_lambda.py
+++ b/services/idp/src/pdf_split_lambda.py
@@ -106,8 +106,8 @@ def _handle_record(record: dict, document_id: str | None = None) -> None:
     bucket = record.get("s3", {}).get("bucket", {}).get("name")
     key = record.get("s3", {}).get("object", {}).get("key")
     bucket_name = get_config("BUCKET_NAME", bucket, key)
-    pdf_raw_prefix = get_config("PDF_RAW_PREFIX", bucket, key) or ""
-    pdf_page_prefix = get_config("PDF_PAGE_PREFIX", bucket, key) or "pdf-pages/"
+    pdf_raw_prefix = get_config("PDF_RAW_PREFIX", bucket, key) or os.environ.get("PDF_RAW_PREFIX", "")
+    pdf_page_prefix = get_config("PDF_PAGE_PREFIX", bucket, key) or os.environ.get("PDF_PAGE_PREFIX")
     if pdf_raw_prefix and not pdf_raw_prefix.endswith("/"):
         pdf_raw_prefix += "/"
     if pdf_page_prefix and not pdf_page_prefix.endswith("/"):

--- a/services/idp/src/pdf_text_extractor_lambda.py
+++ b/services/idp/src/pdf_text_extractor_lambda.py
@@ -171,8 +171,8 @@ def _handle_record(record: dict) -> None:
     bucket = record.get("s3", {}).get("bucket", {}).get("name")
     key = record.get("s3", {}).get("object", {}).get("key")
     bucket_name = get_config("BUCKET_NAME", bucket, key)
-    pdf_text_page_prefix = get_config("PDF_TEXT_PAGE_PREFIX", bucket, key) or "text-pages/"
-    text_page_prefix = get_config("TEXT_PAGE_PREFIX", bucket, key) or "text-pages/"
+    pdf_text_page_prefix = get_config("PDF_TEXT_PAGE_PREFIX", bucket, key) or os.environ.get("PDF_TEXT_PAGE_PREFIX")
+    text_page_prefix = get_config("TEXT_PAGE_PREFIX", bucket, key) or os.environ.get("TEXT_PAGE_PREFIX")
     if pdf_text_page_prefix and not pdf_text_page_prefix.endswith("/"):
         pdf_text_page_prefix += "/"
     if text_page_prefix and not text_page_prefix.endswith("/"):

--- a/services/idp/template.yaml
+++ b/services/idp/template.yaml
@@ -36,6 +36,21 @@ Parameters:
   TEXT_DOC_PREFIX:
     Type: String
     Default: text-docs/
+  PDF_RAW_PREFIX:
+    Type: String
+    Default: pdf-raw/
+  PDF_PAGE_PREFIX:
+    Type: String
+    Default: pdf-pages/
+  PDF_TEXT_PAGE_PREFIX:
+    Type: String
+    Default: text-pages/
+  PDF_SCAN_PAGE_PREFIX:
+    Type: String
+    Default: scan-pages/
+  TEXT_PAGE_PREFIX:
+    Type: String
+    Default: text-pages/
   OCR_ENGINE:
     Type: String
     Default: easyocr
@@ -68,6 +83,11 @@ Globals:
         COMBINE_PREFIX: !Ref COMBINE_PREFIX
         OUTPUT_PREFIX: !Ref OUTPUT_PREFIX
         TEXT_DOC_PREFIX: !Ref TEXT_DOC_PREFIX
+        PDF_RAW_PREFIX: !Ref PDF_RAW_PREFIX
+        PDF_PAGE_PREFIX: !Ref PDF_PAGE_PREFIX
+        PDF_TEXT_PAGE_PREFIX: !Ref PDF_TEXT_PAGE_PREFIX
+        PDF_SCAN_PAGE_PREFIX: !Ref PDF_SCAN_PAGE_PREFIX
+        TEXT_PAGE_PREFIX: !Ref TEXT_PAGE_PREFIX
         OCR_ENGINE: !Ref OCR_ENGINE
         DOCUMENT_AUDIT_TABLE: !Ref DocumentAuditTableName
 

--- a/services/zip-processing/src/zip_creation_lambda.py
+++ b/services/zip-processing/src/zip_creation_lambda.py
@@ -23,6 +23,8 @@ from defusedxml import ElementTree as ET
 import json
 import logging
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
+import os
 
 # ─── Logging Configuration ─────────────────────────────────────────────────────
 logger = configure_logger(__name__)
@@ -150,7 +152,10 @@ def assemble_zip_files(event, s3_client=s3_client):
     zip_file_name = event['zipFileName']
     zip_file_name = zip_file_name.split("/")[-1]
     logger.info("zip_file_name:%s", zip_file_name)
-    zip_file_name = f"curated/{zip_file_name}"
+    curated_prefix = get_config("CURATED_PREFIX") or os.environ.get("CURATED_PREFIX", "")
+    if curated_prefix and not curated_prefix.endswith("/"):
+        curated_prefix += "/"
+    zip_file_name = f"{curated_prefix}{zip_file_name}"
 
     pdf_files = [file['pdffile'] for file in event.get('pdfFiles', [])]
     xml_files = event.get('xmlFiles', [])

--- a/services/zip-processing/src/zip_extract_lambda.py
+++ b/services/zip-processing/src/zip_extract_lambda.py
@@ -17,10 +17,12 @@ import logging
 from json import JSONDecodeError
 from botocore.exceptions import ClientError
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 import io
 import zipfile
 import boto3
 import datetime
+import os
 
 # ─── Logging Configuration ─────────────────────────────────────────────────────
 logger = configure_logger(__name__)
@@ -139,8 +141,14 @@ def extract_zip_file(event: dict) -> dict:
         }
         now = datetime.datetime.now()
         date_time_folder = now.strftime('%Y/%m/%d/%H/%M/%S/')
-        folder_path =  f"raw/{date_time_folder}"
-        extracted_file_key = f"processed/summarization/extracted/{date_time_folder}"
+        raw_prefix = get_config("RAW_PREFIX", source_bucket_name, zip_file_key) or os.environ.get("RAW_PREFIX", "")
+        extracted_prefix = get_config("EXTRACTED_PREFIX", source_bucket_name, zip_file_key) or os.environ.get("EXTRACTED_PREFIX", "")
+        if raw_prefix and not raw_prefix.endswith("/"):
+            raw_prefix += "/"
+        if extracted_prefix and not extracted_prefix.endswith("/"):
+            extracted_prefix += "/"
+        folder_path = f"{raw_prefix}{date_time_folder}"
+        extracted_file_key = f"{extracted_prefix}{date_time_folder}"
         zip_file_name = zip_file_name[-1]
         destination_key = f"{folder_path}{zip_file_name}"
         zip_file_name = zip_file_name.split(".")[0]

--- a/services/zip-processing/template.yaml
+++ b/services/zip-processing/template.yaml
@@ -36,6 +36,16 @@ Parameters:
     Type: String
     Description: IAM Role ARN for Lambda functions
 
+  RAW_PREFIX:
+    Type: String
+    Default: raw/
+  EXTRACTED_PREFIX:
+    Type: String
+    Default: processed/summarization/extracted/
+  CURATED_PREFIX:
+    Type: String
+    Default: curated/
+
   FileProcessingStepFunctionArn:
     Type: String
     Description: ARN of the per-file processing state machine
@@ -102,6 +112,9 @@ Resources:
       Environment:
         Variables:
           AWS_ACCOUNT_NAME: !Ref AWSAccountName
+          CURATED_PREFIX: !Ref CURATED_PREFIX
+          RAW_PREFIX: !Ref RAW_PREFIX
+          EXTRACTED_PREFIX: !Ref EXTRACTED_PREFIX
 
   ZipfileCreationLambdaFunction:
     Type: AWS::Serverless::Function

--- a/tests/test_file_processing_lambda.py
+++ b/tests/test_file_processing_lambda.py
@@ -16,7 +16,8 @@ def test_file_processing_lambda(monkeypatch, s3_stub, config):
     prefix = '/parameters/aio/ameritasAI/dev'
     config['/parameters/aio/ameritasAI/SERVER_ENV'] = 'dev'
     config[f'{prefix}/IDP_BUCKET'] = 'dest-bucket'
-    config[f'{prefix}/RAW_PREFIX'] = 'raw/'
+    raw_prefix = 'raw/'
+    config[f'{prefix}/RAW_PREFIX'] = raw_prefix
 
     s3_stub.objects[('bucket', 'path/test.docx')] = b'data'
 
@@ -27,7 +28,7 @@ def test_file_processing_lambda(monkeypatch, s3_stub, config):
     assert resp['statusCode'] == 200
     body = resp['body']
     assert len(body['document_id']) == 32 and all(c in '0123456789abcdef' for c in body['document_id'])
-    assert body['s3_location'] == 's3://dest-bucket/raw/test.docx'
+    assert body['s3_location'] == f's3://dest-bucket/{raw_prefix}test.docx'
     assert body['collection_name'] == 'c'
     # ensure the source file was tagged for deletion rather than removed
     assert ('bucket', 'path/test.docx') in s3_stub.objects
@@ -38,7 +39,8 @@ def test_file_processing_lambda_copy_verification_failed(monkeypatch, s3_stub, c
     prefix = '/parameters/aio/ameritasAI/dev'
     config['/parameters/aio/ameritasAI/SERVER_ENV'] = 'dev'
     config[f'{prefix}/IDP_BUCKET'] = 'dest-bucket'
-    config[f'{prefix}/RAW_PREFIX'] = 'raw/'
+    raw_prefix = 'raw/'
+    config[f'{prefix}/RAW_PREFIX'] = raw_prefix
 
     s3_stub.objects[('bucket', 'path/test.docx')] = b'data'
 


### PR DESCRIPTION
## Summary
- load prefixes from config/env across IDP and zip Lambdas
- expose new prefix parameters in service templates
- document zip-processing prefixes
- update tests to use config values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc75031f8832f9799af5973b78acd