### PR TITLE
Handle cleanup lambda S3 errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,14 @@ _stub_module("PyPDF2", {"PdfReader": _DummyReader, "PdfWriter": object})
 
 @pytest.fixture(autouse=True)
 def external_stubs():
+    _stub_module("botocore", {})
+    _stub_module(
+        "botocore.exceptions",
+        {
+            "ClientError": DummyS3.exceptions.ClientError,
+            "BotoCoreError": Exception,
+        },
+    )
     _stub_module("fitz", {"open": lambda *a, **k: types.SimpleNamespace(page_count=1, __iter__=lambda self: [], __getitem__=lambda self, i: types.SimpleNamespace(get_text=lambda: ""), __enter__=lambda self: self, __exit__=lambda self, exc_type, exc, tb: None)})
     _stub_module("docx", {"Document": lambda *a, **k: types.SimpleNamespace(paragraphs=[types.SimpleNamespace(text="doc text")])})
     _stub_module("pptx", {"Presentation": lambda *a, **k: types.SimpleNamespace(slides=[types.SimpleNamespace(shapes=[types.SimpleNamespace(text="slide text")])])})

--- a/tests/test_pending_delete_cleanup_lambda.py
+++ b/tests/test_pending_delete_cleanup_lambda.py
@@ -36,3 +36,26 @@ def test_cleanup_lambda(monkeypatch, s3_stub):
     assert ('b', 'new.txt') in s3_stub.objects
     assert ('b', 'untagged.txt') in s3_stub.objects
     assert result['deleted'] == 1
+    assert result['failures'] == []
+
+
+def test_cleanup_lambda_handles_client_error(monkeypatch, s3_stub):
+    monkeypatch.setenv('CLEANUP_BUCKETS', 'b')
+    monkeypatch.setenv('DELETE_AFTER_DAYS', '1')
+    monkeypatch.setattr('common_utils.get_ssm.get_config', lambda name, **_: None)
+    module = load_lambda('cleanup', 'services/file-ingestion/src/pending_delete_cleanup_lambda.py')
+    now = datetime.datetime.utcnow()
+    s3_stub.put_object(Bucket='b', Key='old.txt', Body=b'data')
+    s3_stub.tags[('b', 'old.txt')] = {'pending-delete': 'true'}
+    s3_stub.last_modified[('b', 'old.txt')] = now - datetime.timedelta(days=2)
+
+    def fail_delete(Bucket=None, Key=None):
+        raise s3_stub.exceptions.ClientError({'Error': {}}, 'delete_object')
+
+    monkeypatch.setattr(s3_stub, 'delete_object', fail_delete)
+    monkeypatch.setattr(module, '_s3', s3_stub)
+
+    result = module.lambda_handler({}, {})
+    assert ('b', 'old.txt') in s3_stub.objects
+    assert result['deleted'] == 0
+    assert result['failures'] == [{'bucket': 'b', 'key': 'old.txt', 'action': 'delete'}]


### PR DESCRIPTION
## Summary
- catch ClientError for list, tag fetch, and delete operations in the cleanup lambda
- log failures and return a list of failures
- stub botocore exceptions for tests and extend lambda unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bcb8cfd24832f8d6132ebd8b52e43