### PR TITLE
Add HTTPX error handling

### DIFF
--- a/common/layers/llm-invocation-layer/python/llm_invocation/backends.py
+++ b/common/layers/llm-invocation-layer/python/llm_invocation/backends.py
@@ -275,9 +275,10 @@ def invoke_bedrock_openai(payload: Dict[str, Any]) -> Dict[str, Any]:
     try:
         resp = httpx.post(endpoint, json=payload, headers=headers)
         resp.raise_for_status()
-    except HTTPError:
+    except HTTPError as exc:
+        logger.exception("Bedrock OpenAI request failed")
         _bedrock_selector.record_failure(endpoint)
-        raise
+        return {"error": str(exc)}
     else:
         _bedrock_selector.record_success(endpoint)
     return resp.json()
@@ -302,9 +303,10 @@ def invoke_ollama(payload: Dict[str, Any]) -> Dict[str, Any]:
     try:
         resp = httpx.post(endpoint, json=payload)
         resp.raise_for_status()
-    except HTTPError:
+    except HTTPError as exc:
+        logger.exception("Ollama request failed")
         _ollama_selector.record_failure(endpoint)
-        raise
+        return {"error": str(exc)}
     else:
         _ollama_selector.record_success(endpoint)
     return resp.json()

--- a/common/layers/router-layer/python/routellm_integration.py
+++ b/common/layers/router-layer/python/routellm_integration.py
@@ -11,17 +11,28 @@ __all__ = [
 ]
 
 import httpx
+try:  # pragma: no cover - optional dependency
+    from httpx import HTTPError
+except Exception:  # pragma: no cover - allow import without httpx
+    class HTTPError(Exception):
+        pass
+from common_utils import configure_logger
 from common_utils.get_ssm import get_config
 
 ROUTELLM_ENDPOINT = get_config("ROUTELLM_ENDPOINT") or os.environ.get("ROUTELLM_ENDPOINT", "")
+logger = configure_logger(__name__)
 
 
 def forward_to_routellm(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Forward ``payload`` to the configured RouteLLM endpoint."""
     if not ROUTELLM_ENDPOINT:
         raise RuntimeError("ROUTELLM_ENDPOINT not configured")
-    resp = httpx.post(ROUTELLM_ENDPOINT, json=payload)
-    resp.raise_for_status()
+    try:
+        resp = httpx.post(ROUTELLM_ENDPOINT, json=payload)
+        resp.raise_for_status()
+    except HTTPError as exc:
+        logger.exception("RouteLLM request failed")
+        return {"prompts": [], "error": str(exc)}
     return resp.json()
 
 

--- a/services/rag-stack/src/extract_content_lambda.py
+++ b/services/rag-stack/src/extract_content_lambda.py
@@ -11,6 +11,11 @@ import logging
 from common_utils import configure_logger
 import boto3
 import httpx
+try:  # pragma: no cover - optional dependency
+    from httpx import HTTPError
+except Exception:  # pragma: no cover - allow import without httpx
+    class HTTPError(Exception):
+        pass
 
 from typing import Any, Dict
 import json
@@ -60,9 +65,9 @@ def _process_event(event: Dict[str, Any]) -> Dict[str, Any]:
     try:
         r = httpx.post(CONTENT_ENDPOINT, json={"query": query, "context": context_text})
         r.raise_for_status()
-    except Exception:
+    except HTTPError as exc:
         logger.exception("Content service request failed")
-        return {"content": {}}
+        return {"content": {}, "error": str(exc)}
     logger.info("Content service returned status %s", r.status_code)
     return {"content": r.json()}
 

--- a/services/rag-stack/src/extract_entities_lambda.py
+++ b/services/rag-stack/src/extract_entities_lambda.py
@@ -12,7 +12,11 @@ from common_utils import configure_logger
 import boto3
 import httpx
 from botocore.exceptions import BotoCoreError, ClientError
-from httpx import HTTPError
+try:  # pragma: no cover - optional dependency
+    from httpx import HTTPError
+except Exception:  # pragma: no cover - allow import without httpx
+    class HTTPError(Exception):
+        pass
 
 from typing import Any, Dict
 import json

--- a/services/rag-stack/src/rerank_lambda.py
+++ b/services/rag-stack/src/rerank_lambda.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import os
 import logging
 from common_utils import configure_logger
+try:  # pragma: no cover - optional dependency
+    from httpx import HTTPError
+except Exception:  # pragma: no cover - allow import without httpx
+    class HTTPError(Exception):
+        pass
 from typing import Any, Dict, List, Callable
 from pydantic import BaseModel, ValidationError
 import json
@@ -97,7 +102,7 @@ def _nvidia_rerank(query: str, docs: List[str]) -> List[float]:
         resp.raise_for_status()
         data = resp.json()
         return [float(s) for s in data.get("scores", [])]
-    except Exception:  # pragma: no cover - network or dependency issues
+    except HTTPError:  # pragma: no cover - network or dependency issues
         logger.exception("NVIDIA rerank failed")
         return [0.0] * len(docs)
 

--- a/services/summarization/src/load_prompts_lambda.py
+++ b/services/summarization/src/load_prompts_lambda.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 import os
 import logging
 import httpx
+try:  # pragma: no cover - optional dependency
+    from httpx import HTTPError
+except Exception:  # pragma: no cover - allow import without httpx
+    class HTTPError(Exception):
+        pass
 from common_utils import configure_logger
 
 logger = configure_logger(__name__)
@@ -17,16 +22,24 @@ def lambda_handler(event: dict, context: object) -> dict:
     if not PROMPT_ENGINE_ENDPOINT or not workflow_id:
         return {"prompts": [], "llm_params": {}}
 
-    resp = httpx.post(PROMPT_ENGINE_ENDPOINT, json={"workflow_id": workflow_id})
-    resp.raise_for_status()
+    try:
+        resp = httpx.post(PROMPT_ENGINE_ENDPOINT, json={"workflow_id": workflow_id})
+        resp.raise_for_status()
+    except HTTPError as exc:
+        logger.exception("Failed to fetch workflow prompts")
+        return {"prompts": [], "error": str(exc)}
     prompts = resp.json()
 
     sys_prompt = None
     if SYSTEM_WORKFLOW_ID:
-        sresp = httpx.post(
-            PROMPT_ENGINE_ENDPOINT, json={"workflow_id": SYSTEM_WORKFLOW_ID}
-        )
-        sresp.raise_for_status()
+        try:
+            sresp = httpx.post(
+                PROMPT_ENGINE_ENDPOINT, json={"workflow_id": SYSTEM_WORKFLOW_ID}
+            )
+            sresp.raise_for_status()
+        except HTTPError as exc:
+            logger.exception("Failed to fetch system prompt")
+            return {"prompts": [], "error": str(exc)}
         data = sresp.json()
         if data:
             sys_prompt = data[0].get("template")


### PR DESCRIPTION
## Summary
- add try/except HTTPError around HTTPX POST calls
- log failures using `logger.exception`
- return error details on failure
- update OCR and router utilities for error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcca7f0f0832f8f8092e00b492e37