### PR TITLE
Add JSON logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Values are cached by the shared `get_values_from_ssm` helper using
 When the `SSM_CACHE_TABLE` environment variable is defined, the cache
 uses DynamoDB to persist entries across cold starts.
 
+### Logging
+
+The default log level is `INFO` but can be overridden using the `LOG_LEVEL`
+environment variable. Set `LOG_JSON=true` to emit structured logs in JSON
+format.
+
 ### OCR Engine
 
 The `OCR_ENGINE` variable controls which OCR backend to use:

--- a/common/layers/common-utils/python/common_utils/logging_utils.py
+++ b/common/layers/common-utils/python/common_utils/logging_utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import json
 
 __all__ = ["configure_logger"]
 
@@ -13,13 +14,26 @@ def configure_logger(name: str, level: str = "INFO") -> logging.Logger:
     log_level = os.getenv("LOG_LEVEL", level).upper()
     level_const = getattr(logging, log_level, logging.INFO)
     logger.setLevel(level_const)
+
+    class JsonFormatter(logging.Formatter):
+        def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+            payload = {
+                "timestamp": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
+                "level": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+            }
+            return json.dumps(payload)
+
     handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter(
+    if os.getenv("LOG_JSON", "false").lower() == "true":
+        formatter = JsonFormatter()
+    else:
+        formatter = logging.Formatter(
             "%(asctime)s %(levelname)s [%(name)s] %(message)s",
             "%Y-%m-%dT%H:%M:%S%z",
         )
-    )
+    handler.setFormatter(formatter)
     if not logger.handlers:
         logger.addHandler(handler)
     return logger

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -6,6 +6,8 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 
 - `AWS_ACCOUNT_NAME` – scopes stack resources for the file‑assembly, zip‑processing and summarization stacks.
 - `SSM_CACHE_TABLE` – DynamoDB table used by the SSM caching layer.
+- `LOG_LEVEL` – override the default logging level for all services.
+- `LOG_JSON` – set to `true` to output log lines as JSON.
 
 ### ZIP Processing
 


### PR DESCRIPTION
## Summary
- configure logger to output JSON when `LOG_JSON=true`
- document `LOG_LEVEL` and `LOG_JSON` variables in README and environment variable reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd10e262c832fa5d6a7f7e0cbfd0c