### PR TITLE
Add invoke policy for Milvus insert

### DIFF
--- a/services/rag-stack/template.yaml
+++ b/services/rag-stack/template.yaml
@@ -138,13 +138,15 @@ Resources:
               Payload: '{% $states.input %}'
             End: true
         QueryLanguage: JSONata
-      Policies:
-        - LambdaInvokePolicy:
-            FunctionName: !Ref TextChunkFunction
-        - LambdaInvokePolicy:
-            FunctionName: !Ref EmbedFunction
-      Events:
-        NewTextDoc:
+        Policies:
+          - LambdaInvokePolicy:
+              FunctionName: !Ref TextChunkFunction
+          - LambdaInvokePolicy:
+              FunctionName: !Ref EmbedFunction
+          - LambdaInvokePolicy:
+              FunctionName: !Ref MilvusInsertFunctionArn
+        Events:
+          NewTextDoc:
           Type: S3
           Properties:
             Bucket: !Ref BucketName


### PR DESCRIPTION
## Summary
- allow the ingestion state machine to invoke the Milvus insert lambda

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bf6428190832fad07a4a9ee3c0e7c