### PR TITLE
Enable backend selection for RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The repository includes the following directories under `services/`:
 - `idp` – Intelligent Document Processing pipeline (classification, OCR and text extraction)
 - `zip-processing` – extracts PDFs from uploaded archives and assembles new ZIPs
 - `rag-stack` – combined ingestion and retrieval Lambdas used for RAG workflows. Includes a worker that polls the ingestion queue and starts the workflow
-- `vector-db` – manages Milvus collections and search Lambdas
+- `vector-db` – manages Milvus or Elasticsearch backends and search Lambdas
 - `summarization` – Step Function orchestrates retrieval and summary generation into PDF or DOCX reports
 - `llm-gateway` – renders templates and routes requests to the selected LLM backend
 - `knowledge-base` – ingest text snippets and query them through the retrieval stack

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -62,6 +62,7 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `ELASTICSEARCH_URL` – Elasticsearch endpoint.
 - `ELASTICSEARCH_INDEX_PREFIX` – index name prefix used by the proxy.
 - `EPHEMERAL_TABLE` – DynamoDB table storing ephemeral collections.
+- `storage_mode` event field can override the backend per invocation.
 
 ### RAG Retrieval
 

--- a/docs/event_schemas.md
+++ b/docs/event_schemas.md
@@ -114,6 +114,7 @@ Optionally include an `output_format` property to select `pdf`, `docx`, `json` o
 {
   "embedding": [0.1, 0.2, 0.3],
   "top_k": 5,
+  "storage_mode": "elastic",
   "collection_name": "my-collection",
   "department": "corp",
   "file_guid": "guid"
@@ -126,7 +127,7 @@ Optionally include an `output_format` property to select `pdf`, `docx`, `json` o
 {
   "collection_name": "my-collection",
   "query": "Explain AI",
-  "retrieve_params": {"top_k": 5},
+  "retrieve_params": {"top_k": 5, "storage_mode": "elastic"},
   "router_params": {"backend": "bedrock"},
   "llm_params": {"model": "llama2"}
 }
@@ -152,7 +153,8 @@ Optionally include an `output_format` property to select `pdf`, `docx`, `json` o
   "collection_name": "my-collection",
   "query": "What is AI?",
   "file_guid": "guid",
-  "department": "sales"
+  "department": "sales",
+  "storage_mode": "elastic"
 }
 ```
 

--- a/docs/knowledge_rag_usage.md
+++ b/docs/knowledge_rag_usage.md
@@ -5,7 +5,7 @@ This guide covers recommended practices for ingesting documents into the knowled
 ## Ingesting Documents
 
 1. Use the `/kb/ingest` endpoint provided by the **knowledge-base** service or invoke the `ingest-lambda` function directly.
-2. Always include `collection_name` to specify the target Milvus collection where embeddings should be stored.
+2. Always include `collection_name` to specify the target collection where embeddings should be stored. The backend defaults to Milvus but can be changed to Elasticsearch by passing `storage_mode`.
 3. Include optional metadata fields such as `department`, `team`, `user` and `entities` in your request. These values are stored with each chunk and can later be used to filter queries.
 4. Large files should be processed by the IDP pipeline first and then passed to the ingestion Step Function from `rag-stack`.
 5. Tune the chunk size and overlap through the `CHUNK_SIZE` and `CHUNK_OVERLAP` parameters in Parameter Store to balance retrieval accuracy and cost.
@@ -13,7 +13,7 @@ This guide covers recommended practices for ingesting documents into the knowled
 ## Querying the Knowledge Base
 
 1. Use `/kb/query` to search the indexed documents. Provide natural language queries and optionally pass the same metadata fields (`department`, `team`, `user`, `entities`) to narrow results.
-2. Specify the same `collection_name` used during ingestion so the search runs against the correct Milvus collection. Provide a `file_guid` to limit results to chunks from a single document.
+2. Specify the same `collection_name` used during ingestion so the search runs against the correct collection. Provide a `file_guid` to limit results to chunks from a single document. Set `storage_mode` to `elastic` when querying Elasticsearch.
 3. The query Lambda calls the summarization with context function from the `rag-stack` stack. Configure `VECTOR_SEARCH_FUNCTION` to `HybridSearchFunctionArn` for keyword filtering in addition to vector similarity.
 4. Enable the re-rank Lambda when higher quality ordering of results is required. Set `RERANK_FUNCTION` in the retrieval stack to the ARN of `rerank-lambda`.
 5. Summaries returned from `/kb/query` come from the LLM Gateway. Adjust router settings as documented in [docs/router_configuration.md](router_configuration.md) to experiment with different models.

--- a/docs/rag_architecture.md
+++ b/docs/rag_architecture.md
@@ -8,7 +8,7 @@ This guide illustrates how the retrieval augmented generation components connect
 - **idp** – Intelligent Document Processing pipeline used by file-ingestion for OCR and classification.
 - **rag-stack** – chunks documents, generates embeddings and performs retrieval.
 - **rag-stack-worker** – polls `IngestionQueue` and starts the ingestion workflow, moving failed messages to a DLQ. The queue URL is exported as `IngestionQueueUrl` for other stacks.
-- **vector-db** – maintains Milvus collections used for semantic search.
+- **vector-db** – manages Milvus or Elasticsearch backends used for semantic search.
 - **knowledge-base** – stores metadata for ingested chunks and exposes `/kb/*` endpoints.
 - **summarization** – Step Function workflow that can call retrieval functions when creating summaries.
 
@@ -51,7 +51,7 @@ sequenceDiagram
 
 The summarization Step Function may invoke retrieval during its workflow to supply
 relevant context before generating the final response. Both ingestion and
-retrieval rely on the `vector-db` service to manage Milvus collections.
+retrieval rely on the `vector-db` service to manage vector database backends.
 
 In a typical flow the `file-ingestion` Step Function copies the file to the IDP
 bucket and waits until text extraction completes. After the IDP pipeline

--- a/services/rag-stack/src/extract_content_lambda.py
+++ b/services/rag-stack/src/extract_content_lambda.py
@@ -49,9 +49,13 @@ def _process_event(event: Dict[str, Any]) -> Dict[str, Any]:
     emb = event.get("embedding")
     logger.info("Invoking vector search function %s", LAMBDA_FUNCTION)
     try:
+        payload = {"embedding": emb}
+        storage_mode = event.get("storage_mode")
+        if storage_mode:
+            payload["storage_mode"] = storage_mode
         resp = lambda_client.invoke(
             FunctionName=LAMBDA_FUNCTION,
-            Payload=json.dumps({"embedding": emb}).encode("utf-8"),
+            Payload=json.dumps(payload).encode("utf-8"),
         )
         result = json.loads(resp["Payload"].read())
     except Exception:

--- a/services/rag-stack/src/extract_entities_lambda.py
+++ b/services/rag-stack/src/extract_entities_lambda.py
@@ -58,9 +58,13 @@ def _process_event(event: Dict[str, Any]) -> Dict[str, Any]:
     emb = event.get("embedding")
     logger.info("Invoking vector search function %s", LAMBDA_FUNCTION)
     try:
+        payload = {"embedding": emb}
+        storage_mode = event.get("storage_mode")
+        if storage_mode:
+            payload["storage_mode"] = storage_mode
         resp = lambda_client.invoke(
             FunctionName=LAMBDA_FUNCTION,
-            Payload=json.dumps({"embedding": emb}).encode("utf-8"),
+            Payload=json.dumps(payload).encode("utf-8"),
         )
         result = json.loads(resp["Payload"].read())
     except (ClientError, BotoCoreError, json.JSONDecodeError) as exc:

--- a/services/rag-stack/src/retrieval_lambda.py
+++ b/services/rag-stack/src/retrieval_lambda.py
@@ -51,6 +51,7 @@ class RetrievalEvent(BaseModel):
     department: str | None = None
     team: str | None = None
     user: str | None = None
+    storage_mode: str | None = None
 
     class Config:
         extra = "allow"
@@ -171,6 +172,8 @@ def _process_event(event: RetrievalEvent) -> Dict[str, Any]:
         if val is not None:
             search_payload[key] = val
     search_payload["collection_name"] = event.collection_name
+    if event.storage_mode:
+        search_payload["storage_mode"] = event.storage_mode
     logger.info(
         "Invoking vector search function %s with payload %s",
         LAMBDA_FUNCTION,


### PR DESCRIPTION
## Summary
- allow specifying `storage_mode` when calling retrieval functions
- pass `storage_mode` through content and entity extractors
- document backend switching in environment variables and usage guides
- update event schema samples and architecture docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c103f5198832f9e2a1b71bce71efe