### PR TITLE
Add ephemeral collection support

### DIFF
--- a/services/vector-db/README.md
+++ b/services/vector-db/README.md
@@ -42,6 +42,19 @@ Collections created for short‑lived experiments can be marked as
 drops any expired collections from Milvus before removing the table
 entries.
 
+To create an ephemeral collection send a `create` request with the
+`ephemeral` flag set to `true` and an `expires_at` UNIX timestamp:
+
+```json
+{
+  "operation": "create",
+  "collection_name": "tmp123",
+  "dimension": 768,
+  "ephemeral": true,
+  "expires_at": 1700000000
+}
+```
+
 ## Environment variables
 
 `template.yaml` exposes several parameters that become Lambda environment

--- a/tests/test_vector_db_ephemeral.py
+++ b/tests/test_vector_db_ephemeral.py
@@ -1,0 +1,86 @@
+import importlib.util
+import os
+import time
+import sys
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeTable:
+    def __init__(self, items=None):
+        self.items = items or []
+        self.put_calls = []
+        self.deleted = []
+
+    def put_item(self, Item=None):
+        self.put_calls.append(Item)
+
+    def scan(self):
+        return {"Items": list(self.items)}
+
+    def delete_item(self, Key=None):
+        self.deleted.append(Key)
+        self.items = [i for i in self.items if i.get("collection_name") != Key.get("collection_name")]
+
+
+class FakeResource:
+    def __init__(self, table):
+        self._table = table
+
+    def Table(self, name):
+        return self._table
+
+
+class FakeMilvus:
+    def __init__(self, collection_name=None, *a, **k):
+        self.collection_name = collection_name or os.environ.get("MILVUS_COLLECTION", "docs")
+        self.created = False
+        self.dropped = False
+
+    def create_collection(self, dimension=768):
+        self.created = True
+
+    def drop_collection(self):
+        self.dropped = True
+
+
+def test_create_ephemeral(monkeypatch):
+    table = FakeTable()
+    monkeypatch.setenv("EPHEMERAL_TABLE", "tbl")
+    monkeypatch.setenv("MILVUS_COLLECTION", "docs")
+    import boto3
+    monkeypatch.setattr(sys.modules["boto3"], "resource", lambda name: FakeResource(table), raising=False)
+    import common_utils.get_ssm as g
+    monkeypatch.setattr(g, "get_config", lambda name, **_: None)
+    import common_utils
+    monkeypatch.setattr(common_utils, "MilvusClient", FakeMilvus)
+    module = load_module("milvus", "services/vector-db/src/milvus_handler_lambda.py")
+    event = {"operation": "create", "ephemeral": True, "expires_at": 100}
+    out = module.lambda_handler(event, {})
+    assert out["created"] is True
+    assert table.put_calls == [{"collection_name": "docs", "expires_at": 100}]
+
+
+def test_cleanup_removes_expired(monkeypatch):
+    now = int(time.time())
+    items = [
+        {"collection_name": "c1", "expires_at": now - 10},
+        {"collection_name": "c2", "expires_at": now + 100},
+    ]
+    table = FakeTable(items)
+    import common_utils.get_ssm as g
+    monkeypatch.setattr(g, "get_config", lambda name, **_: None)
+    monkeypatch.setenv("EPHEMERAL_TABLE", "tbl")
+    import boto3
+    monkeypatch.setattr(sys.modules["boto3"], "resource", lambda name: FakeResource(table), raising=False)
+    module = load_module("cleanup", "services/vector-db/src/jobs/cleanup_ephemeral_lambda.py")
+    module.ddb = FakeResource(table)
+    monkeypatch.setattr(module, "MilvusClient", FakeMilvus)
+    result = module.lambda_handler({}, {})
+    assert result["dropped"] == 1
+    assert table.deleted == [{"collection_name": "c1"}]


### PR DESCRIPTION
## Summary
- allow Milvus `_create` handler to register ephemeral collections in DynamoDB
- document ephemeral collections in Vector DB README
- test ephemeral collection create and cleanup behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c1cef11e4832fbd2ea7c21c3cd50a