### PR TITLE
Enforce KB collection prefix and persistent backend

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -102,6 +102,7 @@ These settings configure the router and invocation Lambdas bundled with the gate
 - `STATE_MACHINE_ARN` – ARN of the main ingestion workflow.
 - `SUMMARY_QUEUE_URL` – queue URL consumed by the query Lambda.
 - `KNOWLEDGE_BASE_NAME` – optional name tag.
+- `KB_VECTOR_DB_BACKEND` – fallback backend for knowledge base ingestion.
 - `DELETE_AFTER_DAYS` – retention days for source files tagged `pending-delete=true`.
 - `CLEANUP_BUCKETS` – comma separated list of buckets scanned by the cleanup Lambda.
 

--- a/docs/knowledge_rag_usage.md
+++ b/docs/knowledge_rag_usage.md
@@ -5,7 +5,7 @@ This guide covers recommended practices for ingesting documents into the knowled
 ## Ingesting Documents
 
 1. Use the `/kb/ingest` endpoint provided by the **knowledge-base** service or invoke the `ingest-lambda` function directly.
-2. Always include `collection_name` to specify the target collection where embeddings should be stored. The backend defaults to Milvus but can be changed to Elasticsearch by passing `storage_mode`.
+2. Always include `collection_name` beginning with `kb_` to specify the target collection where embeddings should be stored. The backend defaults to persistent storage but can be changed by setting `KB_VECTOR_DB_BACKEND`.
 3. Include optional metadata fields such as `department`, `team`, `user` and `entities` in your request. These values are stored with each chunk and can later be used to filter queries.
 4. Large files should be processed by the IDP pipeline first and then passed to the ingestion Step Function from `rag-stack`.
 5. Tune the chunk size and overlap through the `CHUNK_SIZE` and `CHUNK_OVERLAP` parameters in Parameter Store to balance retrieval accuracy and cost.

--- a/services/knowledge-base/template.yaml
+++ b/services/knowledge-base/template.yaml
@@ -12,6 +12,9 @@ Parameters:
   KnowledgeBaseName:
     Type: String
     Default: 'kb'
+  KbVectorDbBackend:
+    Type: String
+    Default: persistent
 
 Globals:
   Function:
@@ -40,6 +43,7 @@ Resources:
           STATE_MACHINE_ARN: !Ref IngestionStateMachineArn
           FILE_INGESTION_STATE_MACHINE_ARN: !Ref FileIngestionStateMachineArn
           KNOWLEDGE_BASE_NAME: !Ref KnowledgeBaseName
+          KB_VECTOR_DB_BACKEND: !Ref KbVectorDbBackend
 
   QueryFunction:
     Type: AWS::Serverless::Function

--- a/template.yaml
+++ b/template.yaml
@@ -21,6 +21,9 @@ Parameters:
   DefaultVectorDbBackend:
     Type: String
     Default: milvus
+  KbVectorDbBackend:
+    Type: String
+    Default: persistent
   BedrockOpenAIEndpoint:
     Type: String
     Default: ''
@@ -76,7 +79,7 @@ Resources:
         VectorDbCollection: !Ref VectorDbCollection
         ElasticsearchUrl: !Ref ElasticsearchUrl
         ElasticsearchIndexPrefix: !Ref ElasticsearchIndexPrefix
-        DefaultVectorDbBackend: !Ref DefaultVectorDbBackend
+        KbVectorDbBackend: !Ref KbVectorDbBackend
 
   RagStackService:
     Type: AWS::Serverless::Application
@@ -117,6 +120,7 @@ Resources:
         IngestionStateMachineArn: !GetAtt RagStackService.Outputs.IngestionStateMachineArn
         FileIngestionStateMachineArn: !GetAtt FileIngestionService.Outputs.FileIngestionStateMachineArn
         SummarizeQueueUrl: !GetAtt SummarizationService.Outputs.SummaryQueueUrl
+        KbVectorDbBackend: !Ref KbVectorDbBackend
 
 
   AnonymizationService:


### PR DESCRIPTION
## Summary
- add KB_VECTOR_DB_BACKEND env var and always pass persistent storage mode
- ensure collection names for knowledge base start with `kb_`
- expose `KbVectorDbBackend` parameter in KB and root templates
- document new setting and update usage guide
- adjust unit tests for new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cb3423248832fbb857c00e78ec1c7