### PR TITLE
Add docker-compose for vector-db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.16] - 2025-07-08
+### Added
+- `docker-compose.yml` for the vector-db service to simplify local testing.
+
 ## [1.0.15] - 2025-07-07
 ### Added
 - JSON logging option controlled by the `LOG_JSON` environment variable with

--- a/services/vector-db/docker-compose.yml
+++ b/services/vector-db/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/vector-db/Dockerfile
+    environment:
+      DEFAULT_VECTOR_DB_BACKEND: milvus
+      MILVUS_HOST: localhost
+      MILVUS_PORT: "19530"
+      MILVUS_COLLECTION: docs
+      ELASTICSEARCH_URL: http://localhost:9200
+      ELASTICSEARCH_INDEX_PREFIX: docs
+      EPHEMERAL_TABLE: ephemeral-table
+    ports:
+      - "9011:8080"


### PR DESCRIPTION
## Summary
- add docker compose file for the vector-db service
- document change in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc3496c54832f853e881db588950b