### PR TITLE
Add ephemeral Milvus collection for APS

### DIFF
--- a/tests/test_aps_state_machine.py
+++ b/tests/test_aps_state_machine.py
@@ -3,7 +3,9 @@ def test_aps_state_machine_definition():
     with open('use-cases/aps-summarization/template.yaml') as fh:
         content = fh.read()
 
-    assert 'StartAt: ProcessZip' in content
+    assert 'StartAt: CreateCollection' in content
+    assert 'CreateCollection:' in content
     assert 'ProcessZip:' in content
     assert 'PostProcess:' in content
     assert 'ZipFileProcessingStepFunctionArn' in content
+    assert 'VectorDbProxyFunctionArn' in content

--- a/use-cases/aps-summarization/template.yaml
+++ b/use-cases/aps-summarization/template.yaml
@@ -33,6 +33,8 @@ Parameters:
     Type: String
   RAGSummaryFunctionArn:
     Type: String
+  VectorDbProxyFunctionArn:
+    Type: String
   FileProcessingEmailId:
     Type: String
   FontDir:
@@ -93,6 +95,7 @@ Resources:
       Environment:
         Variables:
           FONT_DIR: !Ref FontDir
+          DEFAULT_VECTOR_DB_BACKEND: milvus
 
   ZipSFStartPolicy:
     Type: AWS::IAM::Policy
@@ -107,13 +110,35 @@ Resources:
             Action: states:StartExecution
             Resource: !GetAtt ZipProcessingService.Outputs.ZipFileProcessingStepFunctionArn
 
+  VectorDbInvokePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub '${AWSAccountName}-${AWS::StackName}-vector-db-invoke'
+      Roles:
+        - !Select [1, !Split ['/', !Ref LambdaIAMRoleARN]]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: lambda:InvokeFunction
+            Resource: !Ref VectorDbProxyFunctionArn
+
   APSStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
       Definition:
         Comment: APS summarization wrapper
-        StartAt: ProcessZip
+        StartAt: CreateCollection
         States:
+          CreateCollection:
+            Type: Task
+            Resource: !Ref VectorDbProxyFunctionArn
+            Parameters:
+              operation: create
+              collection_name: aps-summary-collection
+              ephemeral: true
+              expires_at.$: States.Format('{}', States.MathAdd($$.Execution.StartTime, 86400))
+            Next: ProcessZip
           ProcessZip:
             Type: Task
             Resource: arn:aws:states:::states:startExecution.sync
@@ -123,6 +148,8 @@ Resources:
                 workflow_id: aps
                 font_dir: !Ref FontDir
                 labels_path: !Ref LabelsPath
+                collection_name: aps-summary-collection
+                storage_mode: milvus
                 body.$: $.body
             Next: PostProcess
           PostProcess:


### PR DESCRIPTION
## Summary
- extend APS workflow configuration with VectorDbProxyFunctionArn
- allow APSWorkflowFunction to specify default vector backend
- create a temporary Milvus collection before running ZIP processing
- pass collection info downstream
- permit state machine to invoke the vector‑db proxy
- adjust APS state machine tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc605ead8832f8dadaf7c5ca844a2