### PR TITLE
Add SHA256 hash_key to chunk metadata

### DIFF
--- a/services/rag-stack/src/text_chunk_lambda.py
+++ b/services/rag-stack/src/text_chunk_lambda.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import json
 import logging
+import hashlib
 from common_utils import configure_logger
 from chunking import UniversalFileChunker
 
@@ -171,6 +172,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             meta["file_guid"] = file_guid
         if file_name:
             meta["file_name"] = file_name
+        hash_key = hashlib.sha256(c.encode("utf-8")).hexdigest()
+        meta["hash_key"] = hash_key
         chunk_list.append({"text": c, "metadata": meta})
     if EXTRACT_ENTITIES:
         for idx, chunk in enumerate(chunk_list):


### PR DESCRIPTION
## Summary
- compute SHA256 digest for each chunk in `text_chunk_lambda`
- ensure metadata contains `hash_key`
- verify `hash_key` propagation through embedding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ccb7d93e0832f9c9097d46cf5a203