### PR TITLE
Update APS summarization docs

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -57,8 +57,7 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `TOP_K` – default number of search results.
 - `MILVUS_INDEX_PARAMS` – JSON index settings.
 - `MILVUS_METRIC_TYPE` – distance metric for embeddings.
-- `MILVUS_SEARCH_PARAMS` – JSON search parameters.
-- `DEFAULT_VECTOR_DB_BACKEND` – fallback backend for the vector DB proxy.
+- `DEFAULT_VECTOR_DB_BACKEND` – fallback backend for the vector DB proxy (default `milvus`).
 - `ELASTICSEARCH_URL` – Elasticsearch endpoint.
 - `ELASTICSEARCH_INDEX_PREFIX` – index name prefix used by the proxy.
 - `EPHEMERAL_TABLE` – DynamoDB table storing ephemeral collections.

--- a/docs/rag_ingestion_workflow.md
+++ b/docs/rag_ingestion_workflow.md
@@ -56,7 +56,9 @@ flowchart TD
 
 The chunk size and overlap come from `CHUNK_SIZE` and `CHUNK_OVERLAP` (defaults
 `1000` and `100`). When `EXTRACT_ENTITIES` is true, named entities are added to
-each chunk's metadata.
+each chunk's metadata. Every chunk also stores the originating `file_guid`, a
+`hash_key` of the text, the `file_name` and any detected `entities` so that
+queries can filter or trace results back to the source document.
 
 ## Embedding Strategy
 

--- a/docs/summarization_workflow.md
+++ b/docs/summarization_workflow.md
@@ -70,4 +70,6 @@ workflow input.  The APS wrapper forwards both `font_dir` and `labels_path`
 properties to the summarization state machine so custom fonts and labels can be
 used without modifying the underlying service.
 
-Together these components transform uploaded APS archives into searchable summaries packaged as a new ZIP.
+Together these components transform uploaded APS archives into searchable summaries packaged as a new ZIP. The wrapper
+workflow creates a temporary Milvus collection called `aps-summary-collection` which expires 24 hours after the
+execution starts. `DEFAULT_VECTOR_DB_BACKEND` is set to `milvus` so the retrieval steps use this backend by default.

--- a/use-cases/aps-summarization/README.md
+++ b/use-cases/aps-summarization/README.md
@@ -80,6 +80,12 @@ summarization state machine for each PDF and finally assembles a new
 ZIP file.  After the archive is created the APS workflow invokes an
 optional post processing Lambda.
 
+The state machine creates a temporary Milvus collection named
+`aps-summary-collection` for storing embeddings. This collection is
+marked as ephemeral and expires 24&nbsp;hours after the workflow
+starts. `aps_workflow_lambda.py` sets `DEFAULT_VECTOR_DB_BACKEND` to
+`milvus` so the vector operations always target the Milvus backend.
+
 ## Environment variables
 
 `aps_workflow_lambda.py` and the underlying `file_summary_lambda`
@@ -91,6 +97,9 @@ The `file_summary_lambda` also searches this directory for a
 `summary_labels.json` file.  You can override the location or supply an
 SSM parameter name via the `labels_path` property on the workflow input.
 
+The workflow Lambda sets `DEFAULT_VECTOR_DB_BACKEND` to `milvus` so the
+proxy functions store and retrieve embeddings from Milvus by default.
+
 ## Parameters
 
 - `AWSAccountName` – prefix for stack resources.
@@ -98,6 +107,7 @@ SSM parameter name via the `labels_path` property on the workflow input.
 - `FileIngestionStateMachineArn` – ARN of the file ingestion workflow.
 - `PromptEngineEndpoint` – URL of the prompt engine service.
 - `RAGSummaryFunctionArn` – ARN of the retrieval summarization Lambda.
+- `VectorDbProxyFunctionArn` – ARN of the vector DB proxy Lambda.
 - `FileProcessingEmailId` – email address for ZIP processing failure reports.
 - `LambdaIAMRoleARN` – IAM role used by the Lambda function and state machine.
 - `LambdaSubnet1ID` / `LambdaSubnet2ID` – subnets for the Lambda function.
@@ -125,6 +135,7 @@ sam deploy \
     LambdaSubnet2ID=<subnet2> \
     LambdaSecurityGroupID1=<sg1> \
     LambdaSecurityGroupID2=<sg2> \
+    VectorDbProxyFunctionArn=<arn> \
     FileAssembleFunctionArn=<arn> \
     FileIngestionStateMachineArn=<arn> \
     PromptEngineEndpoint=<endpoint> \


### PR DESCRIPTION
## Summary
- mention `aps-summary-collection` and 24 hour expiration in APS docs
- clarify that chunks store `file_guid`, `hash_key`, `file_name` and `entities`
- document default `milvus` backend in environment vars
- update deployment example with new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ccd498524832f8af7d1aee69c0ebf