### PR TITLE
Improve tokenization hashing speed

### DIFF
--- a/docs/tokenization_workflow.md
+++ b/docs/tokenization_workflow.md
@@ -8,7 +8,7 @@ flowchart TD
     A["Request with entity, type & domain"] --> B{"Mapping exists?"}
     B -- Yes --> C["Return stored token"]
     B -- No --> D["Prepend TOKEN_SALT"]
-    D --> E["Hash SHA-256"]
+    D --> E["Hash BLAKE2s"]
     E --> F["Take first 8 chars"]
     F --> G["Prefix with TOKEN_PREFIX"]
     G --> H["Store mapping"]
@@ -26,7 +26,7 @@ flowchart TD
 2. The Lambda checks the DynamoDB mapping table for an existing entry matching all three fields.
 3. If a record is found the stored token is returned. Otherwise a new token is created by:
    - Prepending the value of the `TOKEN_SALT` environment variable to the entity text.
-   - Hashing the result with SHA‑256 and taking the first eight characters.
+   - Hashing the result with BLAKE2s and taking the first eight characters.
    - Prefixing the digest with the string from `TOKEN_PREFIX`.
 4. The mapping of entity to token is stored in DynamoDB so subsequent calls return the same value.
 

--- a/services/entity-tokenization/tokenize-entity-lambda/app.py
+++ b/services/entity-tokenization/tokenize-entity-lambda/app.py
@@ -32,7 +32,10 @@ _table = _dynamo.Table(TABLE_NAME)
 def _generate_token(entity: str) -> str:
     """Return a token for ``entity`` using SALT or a random UUID."""
     if SALT:
-        digest = hashlib.sha256((SALT + entity).encode("utf-8")).hexdigest()[:8]
+        # Using blake2s offers good performance while still providing
+        # deterministic hashing. Only the first eight characters are used,
+        # matching the previous SHA-256 implementation's length.
+        digest = hashlib.blake2s((SALT + entity).encode("utf-8")).hexdigest()[:8]
     else:
         digest = uuid.uuid4().hex[:8]
     return PREFIX + digest

--- a/tests/test_entity_tokenization.py
+++ b/tests/test_entity_tokenization.py
@@ -39,7 +39,7 @@ def test_generate_token(monkeypatch):
     monkeypatch.setenv('TOKEN_SALT', 's')
     module = load_lambda('tokenize', 'services/entity-tokenization/tokenize-entity-lambda/app.py')
     out = module.lambda_handler({'entity': 'Bob', 'entity_type': 'NAME', 'domain': 'gen'}, {})
-    expected = 'tok-' + hashlib.sha256('sBob'.encode()).hexdigest()[:8]
+    expected = 'tok-' + hashlib.blake2s('sBob'.encode()).hexdigest()[:8]
     assert out['token'] == expected
     assert table.items[0]['entity'] == 'Bob'
 


### PR DESCRIPTION
## Summary
- use `hashlib.blake2s` in `_generate_token`
- adjust docs to reflect new hashing algorithm
- update test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ccaa96c58832f8503f2f1e7fc6742