### PR TITLE
Improve token generation efficiency

### DIFF
--- a/services/anonymization/src/tokenize_entities_lambda.py
+++ b/services/anonymization/src/tokenize_entities_lambda.py
@@ -32,7 +32,9 @@ _table = _dynamo.Table(TABLE_NAME)
 def _generate_token(entity: str) -> str:
     """Return a token for ``entity`` using SALT or a random UUID."""
     if SALT:
-        digest = hashlib.sha256((SALT + entity).encode("utf-8")).hexdigest()[:8]
+        digest = hashlib.blake2b(
+            (SALT + entity).encode("utf-8"), digest_size=4
+        ).hexdigest()
     else:
         digest = uuid.uuid4().hex[:8]
     return PREFIX + digest

--- a/tests/test_entity_tokenization.py
+++ b/tests/test_entity_tokenization.py
@@ -39,7 +39,7 @@ def test_generate_token(monkeypatch):
     monkeypatch.setenv('TOKEN_SALT', 's')
     module = load_lambda('tokenize', 'services/anonymization/src/tokenize_entities_lambda.py')
     out = module.lambda_handler({'entity': 'Bob', 'entity_type': 'NAME', 'domain': 'gen'}, {})
-    expected = 'tok-' + hashlib.sha256('sBob'.encode()).hexdigest()[:8]
+    expected = 'tok-' + hashlib.blake2b('sBob'.encode(), digest_size=4).hexdigest()
     assert out['token'] == expected
     assert table.items[0]['entity'] == 'Bob'
 


### PR DESCRIPTION
## Summary
- optimize `_generate_token` by using blake2b hashing
- adjust tokenization test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd4510584832fb71da67901b21d18