### PR TITLE
Use get_config before env for summarization

### DIFF
--- a/services/summarization/src/load_prompts_lambda.py
+++ b/services/summarization/src/load_prompts_lambda.py
@@ -10,11 +10,17 @@ except Exception:  # pragma: no cover - allow import without httpx
     class HTTPError(Exception):
         pass
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 
 logger = configure_logger(__name__)
 
-PROMPT_ENGINE_ENDPOINT = os.environ.get("PROMPT_ENGINE_ENDPOINT")
-SYSTEM_WORKFLOW_ID = os.environ.get("SYSTEM_WORKFLOW_ID")
+PROMPT_ENGINE_ENDPOINT = (
+    get_config("PROMPT_ENGINE_ENDPOINT")
+    or os.environ.get("PROMPT_ENGINE_ENDPOINT")
+)
+SYSTEM_WORKFLOW_ID = get_config("SYSTEM_WORKFLOW_ID") or os.environ.get(
+    "SYSTEM_WORKFLOW_ID"
+)
 
 
 def lambda_handler(event: dict, context: object) -> dict:

--- a/services/summarization/src/summarize_worker_lambda.py
+++ b/services/summarization/src/summarize_worker_lambda.py
@@ -14,6 +14,7 @@ except Exception:  # pragma: no cover - allow import without httpx
     class HTTPError(Exception):
         pass
 from common_utils import configure_logger
+from common_utils.get_ssm import get_config
 try:
     from botocore.exceptions import BotoCoreError, ClientError
 except Exception:  # pragma: no cover - allow missing botocore
@@ -24,8 +25,13 @@ logger = configure_logger(__name__)
 lambda_client = boto3.client("lambda")
 sf_client = boto3.client("stepfunctions")
 
-SUMMARY_FUNCTION_ARN = os.environ.get("RAG_SUMMARY_FUNCTION_ARN")
-PROMPT_ENGINE_ENDPOINT = os.environ.get("PROMPT_ENGINE_ENDPOINT")
+SUMMARY_FUNCTION_ARN = (
+    get_config("RAG_SUMMARY_FUNCTION_ARN")
+    or os.environ.get("RAG_SUMMARY_FUNCTION_ARN")
+)
+PROMPT_ENGINE_ENDPOINT = (
+    get_config("PROMPT_ENGINE_ENDPOINT") or os.environ.get("PROMPT_ENGINE_ENDPOINT")
+)
 
 
 def _invoke_summary(body: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_load_prompts_lambda.py
+++ b/tests/test_load_prompts_lambda.py
@@ -13,6 +13,10 @@ def load_lambda(name, path):
 def test_load_prompts(monkeypatch):
     monkeypatch.setenv("PROMPT_ENGINE_ENDPOINT", "http://engine")
     monkeypatch.setenv("SYSTEM_WORKFLOW_ID", "sys")
+    monkeypatch.setattr(
+        "common_utils.get_ssm.get_config",
+        lambda name, **_: None,
+    )
     sent = []
 
     class Resp:

--- a/tests/test_summarize_worker.py
+++ b/tests/test_summarize_worker.py
@@ -14,6 +14,10 @@ def load_lambda(name, path):
 def test_worker_prompt_engine(monkeypatch):
     monkeypatch.setenv("RAG_SUMMARY_FUNCTION_ARN", "arn")
     monkeypatch.setenv("PROMPT_ENGINE_ENDPOINT", "http://engine")
+    monkeypatch.setattr(
+        "common_utils.get_ssm.get_config",
+        lambda name, **_: None,
+    )
 
     invoked = {}
     success = {}
@@ -75,6 +79,10 @@ def test_worker_prompt_engine(monkeypatch):
 
 def test_worker_legacy_fallback(monkeypatch):
     monkeypatch.setenv("RAG_SUMMARY_FUNCTION_ARN", "arn")
+    monkeypatch.setattr(
+        "common_utils.get_ssm.get_config",
+        lambda name, **_: None,
+    )
 
     invoked = {}
     success = {}


### PR DESCRIPTION
## Summary
- look up summarization config via `get_config` before using env vars
- adapt summarization tests to stub `get_config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd7145688832fa1eb62bf59e50a22