### PR TITLE
Index token mappings by entity and type

### DIFF
--- a/docs/entity_tokenization_service.md
+++ b/docs/entity_tokenization_service.md
@@ -13,6 +13,10 @@ UUID and stored in the table.
 | `TOKEN_PREFIX` | Prefix added to generated tokens. |
 | `TOKEN_SALT` | Optional salt for deterministic hashing. |
 
+The ``TOKEN_TABLE`` uses ``entity`` as the partition key and ``entity_type`` as
+the sort key. A ``DomainIndex`` global secondary index is provided with
+``entity`` as the partition key and ``domain`` as the sort key.
+
 ## Example
 
 Send a request to the API endpoint or invoke the Lambda directly:

--- a/docs/tokenization_workflow.md
+++ b/docs/tokenization_workflow.md
@@ -23,7 +23,7 @@ flowchart TD
 ## Consistent Token Generation
 
 1. Incoming requests provide an `entity`, its `entity_type` and optional `domain`.
-2. The Lambda checks the DynamoDB mapping table for an existing entry matching all three fields.
+2. The Lambda checks the DynamoDB mapping table for an existing entry matching all three fields. The table is keyed by ``entity`` and ``entity_type`` and includes a ``DomainIndex`` to query by domain.
 3. If a record is found the stored token is returned. Otherwise a new token is created by:
    - Prepending the value of the `TOKEN_SALT` environment variable to the entity text.
    - Hashing the result with SHA‑256 and taking the first eight characters.

--- a/services/anonymization/README.md
+++ b/services/anonymization/README.md
@@ -42,7 +42,7 @@ This consolidated service groups three Lambdas for detecting, tokenizing and ano
 
 ### DynamoDB tables
 
-The `tokenize_entities_lambda` uses the `TOKEN_TABLE` DynamoDB table to persist entity/token mappings. The table name is exported as `TokenTableName` for other stacks.
+The `tokenize_entities_lambda` uses the `TOKEN_TABLE` DynamoDB table to persist entity/token mappings. The table stores items with `entity` as the partition key and `entity_type` as the sort key. A `DomainIndex` GSI allows lookups by domain. The table name is exported as `TokenTableName` for other stacks.
 
 ## Deployment
 

--- a/services/anonymization/template.yaml
+++ b/services/anonymization/template.yaml
@@ -84,11 +84,26 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
-        - AttributeName: token
+        - AttributeName: entity
+          AttributeType: S
+        - AttributeName: entity_type
+          AttributeType: S
+        - AttributeName: domain
           AttributeType: S
       KeySchema:
-        - AttributeName: token
+        - AttributeName: entity
           KeyType: HASH
+        - AttributeName: entity_type
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: DomainIndex
+          KeySchema:
+            - AttributeName: entity
+              KeyType: HASH
+            - AttributeName: domain
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
       BillingMode: PAY_PER_REQUEST
       TableName: !Ref TokenTableName
 

--- a/tests/test_entity_tokenization.py
+++ b/tests/test_entity_tokenization.py
@@ -15,8 +15,19 @@ class FakeTable:
     def __init__(self, items=None):
         self.items = items or []
 
-    def scan(self):
-        return {"Items": list(self.items)}
+    def query(self, **kwargs):
+        vals = kwargs.get("ExpressionAttributeValues", {})
+        e = vals.get(":e")
+        d = vals.get(":d")
+        t = vals.get(":t")
+        items = [
+            i
+            for i in self.items
+            if i.get("entity") == e
+            and i.get("domain") == d
+            and i.get("entity_type") == t
+        ]
+        return {"Items": items}
 
     def put_item(self, Item=None):
         self.items.append(Item)


### PR DESCRIPTION
## Summary
- make `entity`, `entity_type` and `domain` key attributes in the token table
- query the token table by entity, type and domain
- document the new table schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd7f1574c832fa8db3c0edd44b18a