### PR TITLE
Centralize Lambda error handling

### DIFF
--- a/common/layers/common-utils/python/common_utils/__init__.py
+++ b/common/layers/common-utils/python/common_utils/__init__.py
@@ -31,6 +31,7 @@ from .milvus_client import MilvusClient, VectorItem, SearchResult, GetResult
 from .elasticsearch_client import ElasticsearchClient
 from .entity_extraction import extract_entities
 from .lambda_response import lambda_response
+from .error_utils import log_exception, error_response
 from .ner_models import load_ner_model
 from .s3_utils import iter_s3_records
 
@@ -48,6 +49,8 @@ __all__ = [
     "extract_entities",
     "configure_logger",
     "lambda_response",
+    "log_exception",
+    "error_response",
     "load_ner_model",
     "iter_s3_records",
 ]

--- a/common/layers/common-utils/python/common_utils/error_utils.py
+++ b/common/layers/common-utils/python/common_utils/error_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Helpers for consistent error logging and responses."""
+
+from typing import Any, Dict
+import logging
+
+from .lambda_response import lambda_response
+
+__all__ = ["error_response", "log_exception"]
+
+
+def log_exception(message: str, exc: Exception, logger: logging.Logger) -> None:
+    """Log ``exc`` with ``message`` using ``logger``."""
+
+    logger.error("%s: %s", message, exc)
+
+
+def error_response(
+    logger: logging.Logger, status: int, message: str, exc: Exception | None = None
+) -> Dict[str, Any]:
+    """Return ``lambda_response`` with error details after logging ``message``."""
+
+    if exc is not None:
+        logger.error("%s: %s", message, exc)
+    else:
+        logger.error("%s", message)
+    return lambda_response(status, {"error": message})


### PR DESCRIPTION
## Summary
- add `error_utils` with helpers for logging and error responses
- expose `log_exception` and `error_response` in `common_utils`
- refactor file assembly and retrieval lambdas to use new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd99b8604832f80c03087e2ffeffd