### PR TITLE
Improve prompt sanitization with MarkupSafe

### DIFF
--- a/common/layers/router-layer/requirements.txt
+++ b/common/layers/router-layer/requirements.txt
@@ -1,3 +1,4 @@
 httpx==0.28.1
 boto3==1.35.53
 langdetect==1.0.9
+MarkupSafe==2.1.5


### PR DESCRIPTION
## Summary
- escape prompt input using MarkupSafe
- require MarkupSafe in router layer
- validate sanitized prompts in router lambda unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce4615a8c832f8b582492fd0a5b11