### PR TITLE
Refactor router config lookup

### DIFF
--- a/common/layers/router-layer/python/heuristic_router.py
+++ b/common/layers/router-layer/python/heuristic_router.py
@@ -18,11 +18,12 @@ from common_utils.get_ssm import get_config
 
 __all__ = ["HeuristicRouter", "handle_heuristic_route"]
 
-DEFAULT_PROMPT_COMPLEXITY_THRESHOLD = 20
-PROMPT_COMPLEXITY_THRESHOLD = int(
-    get_config("PROMPT_COMPLEXITY_THRESHOLD")
-    or os.environ.get("PROMPT_COMPLEXITY_THRESHOLD", str(DEFAULT_PROMPT_COMPLEXITY_THRESHOLD))
+_THRESHOLD_RAW = get_config("PROMPT_COMPLEXITY_THRESHOLD") or os.environ.get(
+    "PROMPT_COMPLEXITY_THRESHOLD"
 )
+if _THRESHOLD_RAW is None:
+    raise RuntimeError("PROMPT_COMPLEXITY_THRESHOLD not configured")
+PROMPT_COMPLEXITY_THRESHOLD = int(_THRESHOLD_RAW)
 
 
 def _prompt_text(event: Dict[str, Any]) -> str:

--- a/docs/router_configuration.md
+++ b/docs/router_configuration.md
@@ -27,7 +27,7 @@ This document details the environment variables used by the router Lambda that f
 | `OLLAMA_TOP_P` | Nucleus sampling parameter (default `0.9`). |
 | `OLLAMA_MIN_P` | Minimum probability threshold (default `0.05`). |
 | `ALLOWED_BACKENDS` | Comma-separated list of permitted backend names (default `bedrock,ollama`). |
-| `PROMPT_COMPLEXITY_THRESHOLD` | Word count threshold that determines when to switch from Ollama to Bedrock (defaults to `20`). |
+| `PROMPT_COMPLEXITY_THRESHOLD` | Word count threshold that determines when to switch from Ollama to Bedrock. |
 | `ROUTELLM_ENDPOINT` | Optional URL for forwarding requests to a RouteLLM service. |
 | `STRONG_MODEL_ID` | Identifier for the more capable Bedrock model. |
 | `WEAK_MODEL_ID` | Identifier for the lightweight model used with shorter prompts. |

--- a/services/llm-gateway/src/llm_router_lambda.py
+++ b/services/llm-gateway/src/llm_router_lambda.py
@@ -39,11 +39,12 @@ INVOCATION_QUEUE_URL = get_config("INVOCATION_QUEUE_URL") or os.environ.get(
 )
 sqs_client = boto3.client("sqs")
 
-DEFAULT_PROMPT_COMPLEXITY_THRESHOLD = 20
-PROMPT_COMPLEXITY_THRESHOLD = int(
-    get_config("PROMPT_COMPLEXITY_THRESHOLD")
-    or os.environ.get("PROMPT_COMPLEXITY_THRESHOLD", str(DEFAULT_PROMPT_COMPLEXITY_THRESHOLD))
+_THRESHOLD_RAW = get_config("PROMPT_COMPLEXITY_THRESHOLD") or os.environ.get(
+    "PROMPT_COMPLEXITY_THRESHOLD"
 )
+if _THRESHOLD_RAW is None:
+    raise RuntimeError("PROMPT_COMPLEXITY_THRESHOLD not configured")
+PROMPT_COMPLEXITY_THRESHOLD = int(_THRESHOLD_RAW)
 
 # allowlist of permitted backends
 DEFAULT_ALLOWED_BACKENDS = {"bedrock", "ollama"}

--- a/tests/test_predictive_routing.py
+++ b/tests/test_predictive_routing.py
@@ -5,6 +5,7 @@ import io
 
 
 def test_predictive_routing_complex_short(monkeypatch):
+    monkeypatch.setenv("PROMPT_COMPLEXITY_THRESHOLD", "20")
     monkeypatch.setenv("CLASSIFIER_MODEL_ID", "clf")
     monkeypatch.setenv("WEAK_MODEL_ID", "weak")
     monkeypatch.setenv("STRONG_MODEL_ID", "strong")

--- a/tests/test_router_lambda.py
+++ b/tests/test_router_lambda.py
@@ -104,6 +104,7 @@ def test_lambda_handler_invoke_error(monkeypatch):
 
 def test_lambda_handler_malicious_prompt(monkeypatch):
     monkeypatch.setenv("INVOCATION_QUEUE_URL", "url")
+    monkeypatch.setenv("PROMPT_COMPLEXITY_THRESHOLD", "3")
     calls = []
     monkeypatch.setattr(sys.modules["boto3"], "client", lambda name: _make_fake_send(calls))
     module = load_lambda("router_lambda_malicious", "services/llm-gateway/src/llm_router_lambda.py")
@@ -119,6 +120,7 @@ def test_lambda_handler_malicious_prompt(monkeypatch):
 
 def test_lambda_handler_malicious_img_prompt(monkeypatch):
     monkeypatch.setenv("INVOCATION_QUEUE_URL", "url")
+    monkeypatch.setenv("PROMPT_COMPLEXITY_THRESHOLD", "3")
     calls = []
     monkeypatch.setattr(sys.modules["boto3"], "client", lambda name: _make_fake_send(calls))
     module = load_lambda("router_lambda_malicious_img", "services/llm-gateway/src/llm_router_lambda.py")
@@ -134,6 +136,7 @@ def test_lambda_handler_malicious_img_prompt(monkeypatch):
 
 def test_lambda_handler_bad_prompt_type(monkeypatch):
     monkeypatch.setenv("INVOCATION_QUEUE_URL", "url")
+    monkeypatch.setenv("PROMPT_COMPLEXITY_THRESHOLD", "3")
     calls = []
     monkeypatch.setattr(sys.modules["boto3"], "client", lambda name: _make_fake_send(calls))
     module = load_lambda("router_lambda_bad", "services/llm-gateway/src/llm_router_lambda.py")


### PR DESCRIPTION
## Summary
- require PROMPT_COMPLEXITY_THRESHOLD to be provided via SSM or env var
- update heuristic router to match
- document threshold usage
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1258bd98832faaec02a3a2511706