### PR TITLE
Add DLQ for summarization queue

### DIFF
--- a/services/summarization/README.md
+++ b/services/summarization/README.md
@@ -17,6 +17,7 @@ Function.
 
 * **SummarizationWorkflow** – starts at `LoadPrompts` and runs the summarization
   tasks. Messages posted to `SummaryQueue` trigger this workflow.
+  Failed messages are sent to `SummaryDLQ` after five unsuccessful deliveries.
 
 The payload passed to `file-summary-lambda` may include an optional
 `output_format` field which determines the format of the summary file.

--- a/services/summarization/template.yaml
+++ b/services/summarization/template.yaml
@@ -35,10 +35,18 @@ Parameters:
     Type: String
 
 Resources:
+  SummaryDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600
+
   SummaryQueue:
     Type: AWS::SQS::Queue
     Properties:
       VisibilityTimeout: 300
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt SummaryDLQ.Arn
+        maxReceiveCount: 5
 
   PromptEngineLayer:
     Type: AWS::Serverless::LayerVersion
@@ -189,3 +197,6 @@ Outputs:
   SummaryQueueUrl:
     Description: URL of the summary SQS queue
     Value: !Ref SummaryQueue
+  SummaryDLQArn:
+    Description: ARN of the summary dead letter queue
+    Value: !GetAtt SummaryDLQ.Arn

--- a/tests/test_summarization_state_machine.py
+++ b/tests/test_summarization_state_machine.py
@@ -5,3 +5,4 @@ def test_summarization_template_contains_workflow_only():
     assert 'SummarizationWorkflow:' in content
     assert 'FileProcessingStepFunction' not in content
     assert 'SummarizationWorkflowArn' in content
+    assert 'deadLetterTargetArn: !GetAtt SummaryDLQ.Arn' in content


### PR DESCRIPTION
## Summary
- add a SummaryDLQ SQS queue
- hook the DLQ to SummaryQueue using RedrivePolicy
- export the new queue's ARN
- document the DLQ in the summarization README
- check for the RedrivePolicy in tests

## Testing
- `pytest -k summarization_state_machine -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d151e4528832fbdd4d472b7793680