### PR TITLE
Add email classifier service

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -14,6 +14,7 @@ This directory contains individual microservices used to build end‑to‑end AI
 | **summarization** | Orchestrates summarization through a Step Function and outputs PDF or DOCX summaries. |
 | **vector-db** | Unified API for Milvus and Elasticsearch vector storage backends. |
 | **zip-processing** | Extracts PDFs from archives, runs processing for each file and assembles a new ZIP. |
+| **email-classifier-service** | Monitors an inbox, applies rules and routes extracted data. |
 
 Shared Lambda layers reside under `common/layers/` and are referenced by several services.
 

--- a/services/email-classifier-service/Dockerfile
+++ b/services/email-classifier-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.13-slim
+WORKDIR /var/task
+COPY common/layers /opt/layers
+RUN find /opt/layers -name requirements.txt -exec pip install --no-cache-dir -r {} +
+COPY services/email-classifier-service /var/task
+CMD ["python", "src/email_listener_lambda.py"]

--- a/services/email-classifier-service/README.md
+++ b/services/email-classifier-service/README.md
@@ -1,0 +1,63 @@
+# Email Classifier Service
+
+This service monitors an email inbox, applies dynamic rules to incoming
+messages and routes extracted data to the appropriate downstream workflow.
+It generalizes earlier DocuSign‑specific logic so that new email driven
+processes can be configured without code changes.
+
+## Components
+
+### Email Listener
+Connects to the configured mail server and fetches new messages.  All
+evaluation logic has been removed from this component.  Each email is
+forwarded unchanged to the rules engine.
+
+### Rules Engine & Parser
+For every incoming message the engine queries the business rules database
+for an active rule that matches the email's sender, subject or content.
+When a rule matches, its `extractionMap` instructions are used to parse
+the email and extract key data. The result is packaged into a JSON
+object and delivered to the rule's destination such as an Appian
+workflow, webhook or queue.
+
+### Business Rules Database
+Defines how to identify relevant emails, what data to extract and where
+to send the results. Adding new rules enables new workflows without
+updating the service code.
+
+## Rule Schema
+Rules are stored in the `email_classification_rules` table with the
+fields below.  Values are JSON strings so that match criteria and
+extraction logic remain flexible.
+
+| Field           | Description                                                    |
+|-----------------|----------------------------------------------------------------|
+| `ruleName`      | Unique name describing the rule.                               |
+| `priority`      | Numeric priority evaluated in ascending order.                 |
+| `matchCriteria` | JSON map of conditions applied to the email.                   |
+| `extractionMap` | JSON map of fields to extract using regex or other methods.    |
+| `outputAction`  | JSON object describing where the parsed result should be sent. |
+
+### Example
+```json
+{
+  "ruleName": "Classify DocuSign New Account Form",
+  "priority": 1,
+  "matchCriteria": {"from": {"contains": "docusign.net"},
+                     "subject": {"startsWith": "Completed: New Account"}},
+  "extractionMap": {"envelopeId": {"source": "body",
+                                     "regex": "Envelope ID: ([A-Z0-9]+)"}},
+  "outputAction": {"type": "appian", "workflowId": "proc_model_12345"}
+}
+```
+
+By adding another row to the table the service can classify invoices,
+alerts or any other type of message.
+
+## Local Testing
+Build and run the container with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```

--- a/services/email-classifier-service/docker-compose.yml
+++ b/services/email-classifier-service/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: services/email-classifier-service/Dockerfile
+    environment:
+      AWS_ACCOUNT_NAME: dev
+      RULES_TABLE: emailRules
+    ports:
+      - "9010:8080"

--- a/services/email-classifier-service/src/email_listener_lambda.py
+++ b/services/email-classifier-service/src/email_listener_lambda.py
@@ -1,0 +1,33 @@
+"""Email Listener Lambda
+
+Fetches new messages from the configured mailbox and forwards them to the
+rules engine for classification. Filtering is delegated entirely to the
+rules engine.
+"""
+
+from __future__ import annotations
+
+import os
+import boto3
+from botocore.exceptions import ClientError
+from common_utils import configure_logger, lambda_response
+
+logger = configure_logger(__name__)
+_sqs = boto3.client("sqs")
+
+INBOX_QUEUE_URL = os.environ.get("INBOX_QUEUE_URL", "")
+RULES_QUEUE_URL = os.environ.get("RULES_QUEUE_URL", "")
+
+
+def lambda_handler(event, context):  # pragma: no cover - simple pass-through
+    """Receive an email event and forward it to the rules queue."""
+    logger.info("Received email event", extra={"event": event})
+    if not RULES_QUEUE_URL:
+        logger.error("RULES_QUEUE_URL not configured")
+        return lambda_response(500, "Rules queue not configured")
+    try:
+        _sqs.send_message(QueueUrl=RULES_QUEUE_URL, MessageBody=event["body"])
+    except ClientError as exc:
+        logger.exception("Failed to forward email", exc_info=exc)
+        return lambda_response(500, "forward failed")
+    return lambda_response(200, "queued")

--- a/services/email-classifier-service/src/rules_engine_lambda.py
+++ b/services/email-classifier-service/src/rules_engine_lambda.py
@@ -1,0 +1,74 @@
+"""Rules Engine Lambda
+
+Evaluates incoming emails against dynamic rules and extracts data
+according to the matched rule's instructions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import boto3
+from botocore.exceptions import ClientError
+from common_utils import configure_logger, lambda_response
+
+logger = configure_logger(__name__)
+_sqs = boto3.client("sqs")
+_dynamo = boto3.resource("dynamodb")
+
+RULES_TABLE = os.environ.get("RULES_TABLE", "")
+DEST_QUEUE_URL = os.environ.get("DEST_QUEUE_URL", "")
+
+def _load_rules():  # pragma: no cover - simple table scan
+    if not RULES_TABLE:
+        return []
+    table = _dynamo.Table(RULES_TABLE)
+    return table.scan().get("Items", [])
+
+
+def _match(rule, email):
+    crit = json.loads(rule.get("matchCriteria", "{}"))
+    from_crit = crit.get("from", {})
+    subject_crit = crit.get("subject", {})
+    body_crit = crit.get("body", {})
+    sender = email.get("from", "")
+    subject = email.get("subject", "")
+    body = email.get("body", "")
+    if "contains" in from_crit and from_crit["contains"] not in sender:
+        return False
+    if "equals" in from_crit and from_crit["equals"] != sender:
+        return False
+    if "startsWith" in subject_crit and not subject.startswith(subject_crit["startsWith"]):
+        return False
+    if "contains" in subject_crit and subject_crit["contains"] not in subject:
+        return False
+    if "regex" in body_crit:
+        import re
+        if not re.search(body_crit["regex"], body):
+            return False
+    return True
+
+
+def lambda_handler(event, context):  # pragma: no cover - demonstration only
+    email = json.loads(event.get("body", "{}"))
+    for rule in sorted(_load_rules(), key=lambda r: int(r.get("priority", 0))):
+        if _match(rule, email):
+            extraction = json.loads(rule.get("extractionMap", "{}"))
+            result = {}
+            for key, cfg in extraction.items():
+                src = email.get(cfg.get("source", ""), "")
+                regex = cfg.get("regex")
+                if regex:
+                    import re
+                    m = re.search(regex, src)
+                    if m:
+                        result[key] = m.group(1)
+                else:
+                    result[key] = src
+            dest = json.loads(rule.get("outputAction", "{}"))
+            if dest.get("type") == "webhook":
+                _sqs.send_message(QueueUrl=DEST_QUEUE_URL, MessageBody=json.dumps(result))
+            else:
+                _sqs.send_message(QueueUrl=DEST_QUEUE_URL, MessageBody=json.dumps(result))
+            return lambda_response(200, result)
+    return lambda_response(204, "no match")

--- a/services/email-classifier-service/template.yaml
+++ b/services/email-classifier-service/template.yaml
@@ -1,0 +1,55 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Lambdas for classifying incoming emails using dynamic rules.
+
+Parameters:
+  RulesTable:
+    Type: String
+  InboxQueueUrl:
+    Type: String
+  OutputQueueUrl:
+    Type: String
+
+Resources:
+  EmailListenerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: email_listener_lambda.lambda_handler
+      Runtime: python3.13
+      Environment:
+        Variables:
+          RULES_QUEUE_URL: !Ref RulesQueue
+      Events:
+        Queue:
+          Type: SQS
+          Properties:
+            Queue: !Ref InboxQueue
+
+  RulesEngineFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: rules_engine_lambda.lambda_handler
+      Runtime: python3.13
+      Environment:
+        Variables:
+          RULES_TABLE: !Ref RulesTable
+          DEST_QUEUE_URL: !Ref OutputQueue
+
+  InboxQueue:
+    Type: AWS::SQS::Queue
+
+  RulesQueue:
+    Type: AWS::SQS::Queue
+
+  OutputQueue:
+    Type: AWS::SQS::Queue
+
+Outputs:
+  InboxQueueUrl:
+    Value: !Ref InboxQueue
+  RulesQueueUrl:
+    Value: !Ref RulesQueue
+  OutputQueueUrl:
+    Value: !Ref OutputQueue


### PR DESCRIPTION
## Summary
- create new email-classifier-service with Dockerfile, sample Lambdas and template
- document the service architecture
- list email-classifier-service in services overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8fa09b88832fb162a2c08612e1fb