### PR TITLE
Add Presidio packages to common utils layer

### DIFF
--- a/common/layers/common-utils/requirements.txt
+++ b/common/layers/common-utils/requirements.txt
@@ -2,3 +2,9 @@ boto3==1.35.53
 elasticsearch==8.12.0
 pydantic==2.7.1
 aws-lambda-powertools==2.34.1
+
+presidio-analyzer
+presidio-anonymizer
+spacy
+transformers
+torch


### PR DESCRIPTION
## Summary
- add presidio packages to common-utils layer requirements
- include spacy, transformers and torch

## Testing
- `pytest -q`
- `sam build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1173d1fc832fb4973f162b2910d8