### PR TITLE
Extend anonymization to use Presidio and add confidence filtering

### DIFF
--- a/services/anonymization/src/mask_text_lambda.py
+++ b/services/anonymization/src/mask_text_lambda.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 import httpx
 try:  # pragma: no cover - optional dependency
@@ -20,13 +20,54 @@ logger = configure_logger(__name__)
 MODE = (get_config("ANON_MODE") or os.environ.get("ANON_MODE", "mask")).lower()
 TOKEN_API_URL = get_config("TOKEN_API_URL") or os.environ.get("TOKEN_API_URL", "")
 TIMEOUT = float(get_config("ANON_TIMEOUT") or os.environ.get("ANON_TIMEOUT", "3"))
+CONF_THRESHOLD = float(
+    get_config("ANON_CONFIDENCE") or os.environ.get("ANON_CONFIDENCE", "0")
+)
+
+USE_PRESIDIO = (
+    (get_config("USE_PRESIDIO_ANON") or os.environ.get("USE_PRESIDIO_ANON"))
+    in {"1", "true", "True"}
+)
+
+try:  # pragma: no cover - optional dependency
+    from presidio_anonymizer import AnonymizerEngine
+    from presidio_anonymizer.entities import OperatorConfig, RecognizerResult
+    _PRESIDIO_ENGINE = AnonymizerEngine()
+except Exception:  # pragma: no cover - allow import without dependency
+    USE_PRESIDIO = False
+    _PRESIDIO_ENGINE = None
 
 _fake = Faker()
 
 
+def _normalize_entities(text: str, entities: Iterable[Any]) -> List[Dict[str, Any]]:
+    """Return a normalized list of entity dictionaries."""
+
+    norm: List[Dict[str, Any]] = []
+    for ent in entities:
+        if hasattr(ent, "to_dict"):
+            ent = ent.to_dict()
+        elif not isinstance(ent, dict):
+            ent = {
+                "start": getattr(ent, "start", 0),
+                "end": getattr(ent, "end", 0),
+                "score": getattr(ent, "score", None),
+                "type": getattr(ent, "entity_type", getattr(ent, "type", "")),
+            }
+
+        start = int(ent.get("start", 0))
+        end = int(ent.get("end", start))
+        typ = ent.get("type") or ent.get("entity_type", "")
+        score = ent.get("score")
+        chunk = text[start:end] if not ent.get("text") else ent.get("text")
+        norm.append({"text": chunk, "type": typ, "start": start, "end": end, "score": score})
+
+    return norm
+
+
 def _mask(ent: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
-    text = ent.get("text", "")
-    replacement = "*" * len(text)
+    typ = ent.get("type", "ENTITY")
+    replacement = f"[{typ}]"
     return replacement, {"replacement": replacement, **ent}
 
 
@@ -74,11 +115,60 @@ _REPLACERS = {
 }
 
 
+def _presidio_apply(text: str, entities: List[Dict[str, Any]]) -> Tuple[str, List[Dict[str, Any]]]:
+    """Mask text using the presidio anonymizer."""
+
+    if not _PRESIDIO_ENGINE:
+        return text, []
+
+    results = [
+        RecognizerResult(ent["type"], ent["start"], ent["end"], ent.get("score", 1.0))
+        for ent in entities
+    ]
+
+    ops: Dict[str, OperatorConfig] = {}
+    for ent in entities:
+        if ent["type"] not in ops:
+            ops[ent["type"]] = OperatorConfig("replace", {"new_value": f"[{ent['type']}]"})
+
+    try:
+        res = _PRESIDIO_ENGINE.anonymize(text=text, analyzer_results=results, operators=ops)
+    except Exception:  # pragma: no cover - optional dependency failure
+        logger.exception("Presidio anonymization failed")
+        return text, []
+
+    repls = [
+        {
+            "type": item["entity_type"],
+            "start": item["start"],
+            "end": item["end"],
+            "replacement": item["text"],
+        }
+        for item in res.items
+    ]
+    return res.text, repls
+
+
 def _apply(text: str, entities: List[Dict[str, Any]]) -> Tuple[str, List[Dict[str, Any]]]:
+    def _conf(ent: Dict[str, Any]) -> float:
+        score = ent.get("score")
+        if score is None:
+            return 1.0
+        return float(score)
+
+    filtered = [e for e in entities if _conf(e) >= CONF_THRESHOLD]
+    if not filtered:
+        return text, []
+
+    if MODE == "mask" and USE_PRESIDIO:
+        anon_text, replacements = _presidio_apply(text, filtered)
+        if replacements:
+            return anon_text, replacements
+
     parts: List[str] = []
     replacements: List[Dict[str, Any]] = []
     last = 0
-    for ent in sorted(entities, key=lambda e: e.get("start", 0)):
+    for ent in sorted(filtered, key=lambda e: e.get("start", 0)):
         start = int(ent.get("start", 0))
         end = int(ent.get("end", start))
         parts.append(text[last:start])
@@ -94,7 +184,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Entry point for the anonymization Lambda."""
 
     text = event.get("text", "")
-    entities = event.get("entities", [])
+    entities = _normalize_entities(text, event.get("entities", []))
     if not text or not entities:
         return {"text": text}
 

--- a/tests/test_text_anonymization.py
+++ b/tests/test_text_anonymization.py
@@ -58,7 +58,7 @@ def test_mask_mode(monkeypatch, load_app, config):
     monkeypatch.setenv("ANON_MODE", "mask")
     module = load_app()
     out = module.lambda_handler(_event(), {})
-    assert out == {"text": "***** met ***."}
+    assert out == {"text": "[PERSON] met [PERSON]."}
 
 
 def test_pseudonymization(monkeypatch, load_app, faker_stub, config):
@@ -111,3 +111,14 @@ def test_tokenization_timeout(monkeypatch, load_app, config):
     assert out["text"] == "[REMOVED] met [REMOVED]."
     repl = out.get("replacements", [])
     assert [r["replacement"] for r in repl] == ["[REMOVED]", "[REMOVED]"]
+
+
+def test_confidence_threshold(monkeypatch, load_app, config):
+    monkeypatch.setenv("ANON_MODE", "mask")
+    monkeypatch.setenv("ANON_CONFIDENCE", "0.9")
+    module = load_app()
+    event = _event()
+    event["entities"][0]["score"] = 0.8
+    event["entities"][1]["score"] = 0.95
+    out = module.lambda_handler(event, {})
+    assert out == {"text": "Alice met [PERSON]."}


### PR DESCRIPTION
## Summary
- add environment variables for Presidio-based masking and confidence threshold
- replace masking output with entity type placeholders
- support Presidio detection output and optional anonymizer
- skip entities below configured confidence
- update unit tests

## Testing
- `pytest tests/test_text_anonymization.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1726df80832fac476716754cf74b