### PR TITLE
Add Presidio options to anonymization service

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -127,6 +127,8 @@ These settings configure the router and invocation Lambdas bundled with the gate
 - `ANON_MODE` – how to anonymize text: `mask`, `pseudo` or `token`.
 - `TOKEN_API_URL` – endpoint for tokenization when using token mode.
 - `ANON_TIMEOUT` – seconds before falling back to `[REMOVED]`.
+- `PRESIDIO_LANGUAGE` – language code passed to Presidio.
+- `PRESIDIO_CONFIDENCE` – confidence threshold when using Presidio.
 
 ### EFS Storage
 

--- a/services/anonymization/README.md
+++ b/services/anonymization/README.md
@@ -43,6 +43,8 @@ services with appropriate IAM roles.
 | `AnonymizationMode` | `ANON_MODE` | `mask`, `pseudo` or `token`. |
 | `TokenApiUrl` | `TOKEN_API_URL` | URL of the tokenization Lambda. |
 | `AnonymizationTimeout` | `ANON_TIMEOUT` | Seconds before falling back to `[REMOVED]`. |
+| `PresidioLanguage` | `PRESIDIO_LANGUAGE` | Language code for Presidio. |
+| `PresidioConfidence` | `PRESIDIO_CONFIDENCE` | Confidence threshold for Presidio. |
 
 ### DynamoDB tables
 
@@ -57,6 +59,19 @@ sam deploy --template-file services/anonymization/template.yaml --stack-name ano
 ```
 
 The stack exports `DetectSensitiveInfoFunctionArn`, `TokenizeEntityFunctionArn`, `AnonymizeTextFunctionArn` and `TokenTableName` for use by other services.
+
+### Presidio workflow
+
+Set `USE_PRESIDIO_ANON=true` to apply the Presidio anonymizer when `ANON_MODE` is
+`mask`. The `PresidioLanguage` and `PresidioConfidence` parameters configure the
+language and confidence threshold used by Presidio.
+
+Example deployment:
+
+```bash
+sam deploy \
+  --parameter-overrides PresidioLanguage=en PresidioConfidence=0.85
+```
 
 
 ## Local testing

--- a/services/anonymization/docker-compose.yml
+++ b/services/anonymization/docker-compose.yml
@@ -12,5 +12,7 @@ services:
       TOKEN_API_URL: ""
       ANON_TIMEOUT: 3
       ANON_MODE: mask
+      PRESIDIO_LANGUAGE: en
+      PRESIDIO_CONFIDENCE: 0
     ports:
       - "9012:8080"

--- a/services/anonymization/src/mask_text_lambda.py
+++ b/services/anonymization/src/mask_text_lambda.py
@@ -21,7 +21,10 @@ MODE = (get_config("ANON_MODE") or os.environ.get("ANON_MODE", "mask")).lower()
 TOKEN_API_URL = get_config("TOKEN_API_URL") or os.environ.get("TOKEN_API_URL", "")
 TIMEOUT = float(get_config("ANON_TIMEOUT") or os.environ.get("ANON_TIMEOUT", "3"))
 CONF_THRESHOLD = float(
-    get_config("ANON_CONFIDENCE") or os.environ.get("ANON_CONFIDENCE", "0")
+    get_config("PRESIDIO_CONFIDENCE")
+    or get_config("ANON_CONFIDENCE")
+    or os.environ.get("PRESIDIO_CONFIDENCE")
+    or os.environ.get("ANON_CONFIDENCE", "0")
 )
 
 USE_PRESIDIO = (

--- a/services/anonymization/template.yaml
+++ b/services/anonymization/template.yaml
@@ -42,6 +42,12 @@ Parameters:
   AnonymizationTimeout:
     Type: Number
     Default: 3
+  PresidioLanguage:
+    Type: String
+    Default: 'en'
+  PresidioConfidence:
+    Type: Number
+    Default: 0
 
 Globals:
   Function:
@@ -80,6 +86,7 @@ Resources:
           LEGAL_MODEL: !Ref LegalModel
           REGEX_PATTERNS: !Ref RegexPatterns
           LEGAL_REGEX_PATTERNS: !Ref LegalRegexPatterns
+          PRESIDIO_LANGUAGE: !Ref PresidioLanguage
       Events:
         Api:
           Type: Api
@@ -150,6 +157,8 @@ Resources:
           ANON_MODE: !Ref AnonymizationMode
           TOKEN_API_URL: !Ref TokenApiUrl
           ANON_TIMEOUT: !Ref AnonymizationTimeout
+          ANON_CONFIDENCE: !Ref PresidioConfidence
+          PRESIDIO_CONFIDENCE: !Ref PresidioConfidence
       Events:
         Api:
           Type: Api


### PR DESCRIPTION
## Summary
- add `PresidioLanguage` and `PresidioConfidence` parameters
- expose these as env vars on detection and anonymization Lambdas
- support new vars in Lambda code
- document Presidio usage in README and env var reference
- include defaults in docker-compose for local testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e17a7f1f4832f88650bde7baea6fc