### PR TITLE
Remove SSM value from logs

### DIFF
--- a/common/layers/common-utils/python/common_utils/get_ssm.py
+++ b/common/layers/common-utils/python/common_utils/get_ssm.py
@@ -45,7 +45,7 @@ def get_values_from_ssm(name: str, decrypt: bool = False) -> Optional[str]:
             resp = _ssm_client.get_parameter(Name=name, WithDecryption=decrypt)
             value = resp["Parameter"]["Value"]
         _SSM_CACHE[name] = value
-        logger.info("Parameter Value for %s: %s", name, value)
+        logger.info("Loaded parameter %s", name)
         return value
     except (BotoCoreError, ClientError, Exception) as exc:
         logger.error("Error retrieving parameter %s: %s", name, exc)


### PR DESCRIPTION
## Summary
- stop logging SSM parameter values when loaded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fa851bf30832f9c532b833fd98b19