### PR TITLE
Store OCR bounding boxes as JSON

### DIFF
--- a/docs/idp_output_format.md
+++ b/docs/idp_output_format.md
@@ -28,15 +28,20 @@ This document describes the standard Markdown representation for text extracted 
 
 By standardizing on this format, text extracted by different IDP engines can be processed uniformly across downstream services.
 
-## hOCR/XML Output
+## OCR Bounding Box Output
 
-When using the `ocrmypdf` engine, the pipeline also emits hOCR files for each page.
-The HTML contains word-level coordinates that downstream services can parse to
-determine exact bounding boxes. A typical snippet looks like:
+When the `ocrmypdf` engine is selected, each page also produces a JSON file
+containing word-level bounding boxes. Files are written to
+`<HOCR_PREFIX><documentId>/page_<n>.json` and have the following structure:
 
-```html
-<span class='ocrx_word' id='word_1_1' title='bbox 50 717 89 734; x_wconf 90'>Sample</span>
+```json
+{
+  "words": [
+    {"bbox": [50, 717, 89, 734], "text": "Sample"}
+  ]
+}
 ```
 
-Consumers may extract the `bbox` values to map text to document locations.
+The `bbox` values correspond to the coordinates from the original hOCR output
+(`x1`, `y1`, `x2`, `y2`).
 


### PR DESCRIPTION
## Summary
- capture hOCR bounding boxes in JSON per page
- merge bounding box JSON when combining documents
- document new format in idp_output_format.md
- update tests for new page JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687066399e48832fa06a493322d8e6c7