### PR TITLE
Add FORCE_OCR and tests

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -33,6 +33,7 @@ Each service loads its configuration from Parameter Store or the Lambda environm
 - `OCR_ENGINE` – selected OCR engine (`easyocr`, `paddleocr`, `trocr`, `docling`, `ocrmypdf`).
 - `TROCR_ENDPOINT` – TrOCR service URL when using `trocr`.
 - `DOCLING_ENDPOINT` – Docling service URL when using `docling`.
+- `FORCE_OCR` – set to `true` to treat all PDF pages as scanned.
 - `PDF_RAW_PREFIX`, `PDF_PAGE_PREFIX`, `PDF_TEXT_PAGE_PREFIX`, `PDF_SCAN_PAGE_PREFIX`, `TEXT_PAGE_PREFIX` – internal prefixes used by the pipeline.
 - `DPI` – image resolution for OCR.
 - `EDI_SEARCH_API_URL` / `EDI_SEARCH_API_KEY` – external API for IDP output.

--- a/services/idp/template.yaml
+++ b/services/idp/template.yaml
@@ -63,6 +63,9 @@ Parameters:
   DOCLING_ENDPOINT:
     Type: String
     Default: ''
+  FORCE_OCR:
+    Type: String
+    Default: 'false'
   DocumentAuditTableName:
     Type: String
     Default: document-audit
@@ -93,6 +96,7 @@ Globals:
         TEXT_PAGE_PREFIX: !Ref TEXT_PAGE_PREFIX
         HOCR_PREFIX: !Ref HOCR_PREFIX
         OCR_ENGINE: !Ref OCR_ENGINE
+        FORCE_OCR: !Ref FORCE_OCR
         DOCUMENT_AUDIT_TABLE: !Ref DocumentAuditTableName
 
 Resources:

--- a/tests/test_pdf_page_classifier_lambda.py
+++ b/tests/test_pdf_page_classifier_lambda.py
@@ -1,0 +1,63 @@
+import importlib.util
+
+
+def load_lambda(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_event(prefix):
+    return {
+        "Records": [
+            {
+                "s3": {
+                    "bucket": {"name": "bucket"},
+                    "object": {"key": f"{prefix}doc1/page_001.pdf"},
+                }
+            }
+        ]
+    }
+
+def test_pdf_page_classifier_default(monkeypatch, s3_stub, config):
+    prefix = '/parameters/aio/ameritasAI/dev'
+    config['/parameters/aio/ameritasAI/SERVER_ENV'] = 'dev'
+    config[f'{prefix}/BUCKET_NAME'] = 'bucket'
+    pdf_page_prefix = 'pdf-pages/'
+    pdf_text_prefix = 'text-pages/'
+    pdf_scan_prefix = 'scan-pages/'
+    config[f'{prefix}/PDF_PAGE_PREFIX'] = pdf_page_prefix
+    config[f'{prefix}/PDF_TEXT_PAGE_PREFIX'] = pdf_text_prefix
+    config[f'{prefix}/PDF_SCAN_PAGE_PREFIX'] = pdf_scan_prefix
+    module = load_lambda('classifier', 'services/idp/src/pdf_page_classifier_lambda.py')
+
+    s3_stub.objects[('bucket', f'{pdf_page_prefix}doc1/page_001.pdf')] = b'data'
+    monkeypatch.setattr(module, '_page_has_text', lambda b: True)
+
+    event = _make_event(pdf_page_prefix)
+    module.lambda_handler(event, {})
+
+    assert ('bucket', f'{pdf_text_prefix}doc1/page_001.pdf') in s3_stub.objects
+
+def test_pdf_page_classifier_force(monkeypatch, s3_stub, config):
+    prefix = '/parameters/aio/ameritasAI/dev'
+    config['/parameters/aio/ameritasAI/SERVER_ENV'] = 'dev'
+    config[f'{prefix}/BUCKET_NAME'] = 'bucket'
+    pdf_page_prefix = 'pdf-pages/'
+    pdf_text_prefix = 'text-pages/'
+    pdf_scan_prefix = 'scan-pages/'
+    config[f'{prefix}/PDF_PAGE_PREFIX'] = pdf_page_prefix
+    config[f'{prefix}/PDF_TEXT_PAGE_PREFIX'] = pdf_text_prefix
+    config[f'{prefix}/PDF_SCAN_PAGE_PREFIX'] = pdf_scan_prefix
+    config[f'{prefix}/FORCE_OCR'] = 'true'
+    module = load_lambda('classifier_force', 'services/idp/src/pdf_page_classifier_lambda.py')
+
+    s3_stub.objects[('bucket', f'{pdf_page_prefix}doc1/page_001.pdf')] = b'data'
+    monkeypatch.setattr(module, '_page_has_text', lambda b: True)
+
+    event = _make_event(pdf_page_prefix)
+    module.lambda_handler(event, {})
+
+    assert ('bucket', f'{pdf_scan_prefix}doc1/page_001.pdf') in s3_stub.objects
+


### PR DESCRIPTION
## Summary
- add `FORCE_OCR` environment variable to IDP template
- update docs with new option
- support FORCE_OCR flag in pdf page classifier
- add unit tests for page classifier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706806888c832fa6c0039c2151b45d