### PR TITLE
Document PII detection endpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This directory contains guides and reference material for the services in this r
 - [rag_architecture.md](rag_architecture.md) – how ingestion, retrieval and summarization services interact.
 - [event_schemas.md](event_schemas.md) – sample payloads for Lambdas and Step Functions.
 - [entity_tokenization_service.md](entity_tokenization_service.md) – overview of the tokenization Lambda.
+- [pii_detection_service.md](pii_detection_service.md) – detecting sensitive entities without modifying text.
 - [tokenization_workflow.md](tokenization_workflow.md) – generating and rotating tokens securely.
 - [environment_variables.md](environment_variables.md) – common Lambda configuration.
 - [ecr_deployment.md](ecr_deployment.md) – building and pushing container images.

--- a/docs/pii_detection_service.md
+++ b/docs/pii_detection_service.md
@@ -1,0 +1,25 @@
+# PII Detection Service
+
+The `detect_sensitive_info_lambda.py` Lambda extracts personally identifiable information from input text.
+It does **not** modify or anonymize the text. The function is exposed through the `/detect-pii` API endpoint
+in the `anonymization` service.
+
+## Request
+
+Send a JSON payload with a `text` field and optional `domain` value:
+
+```json
+{"text": "Jane Doe 123-45-6789", "domain": "Medical"}
+```
+
+The domain selects a specialized model when provided (`Medical` or `Legal`).
+
+## Response
+
+A JSON object containing the detected entities is returned:
+
+```json
+{"entities": [{"text": "Jane Doe", "type": "PERSON", "start": 0, "end": 8}]}
+```
+
+Each entity includes the matched substring, its type and positional offsets within the original text.

--- a/services/anonymization/README.md
+++ b/services/anonymization/README.md
@@ -28,6 +28,23 @@ services with appropriate IAM roles.
 | `RegexPatterns` | `REGEX_PATTERNS` | JSON map of regex detectors. |
 | `LegalRegexPatterns` | `LEGAL_REGEX_PATTERNS` | JSON map for legal domain. |
 
+### /detect-pii endpoint
+
+Invoke `detect_sensitive_info_lambda.py` through the `/detect-pii` API route.
+The Lambda only returns detected entities and does not modify the input text.
+
+Example request:
+
+```json
+{"text": "Alice met Bob."}
+```
+
+Example response:
+
+```json
+{"entities": [{"text": "Alice", "type": "PERSON", "start": 0, "end": 5}]}
+```
+
 ### tokenize_entities_lambda
 
 | Parameter | Environment variable | Description |


### PR DESCRIPTION
## Summary
- document the detect_sensitive_info Lambda and API
- link to the new doc from the docs index
- expand anonymization service README with /detect-pii details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706cd8e0f4832f9a538e512ecdfefa