### PR TITLE
Allow custom NER models

### DIFF
--- a/docs/pii_detection_service.md
+++ b/docs/pii_detection_service.md
@@ -14,6 +14,10 @@ Send a JSON payload with a `text` field and optional `domain` value:
 
 The domain selects a specialized model when provided (`Medical` or `Legal`).
 
+The Lambda supports both spaCy and HuggingFace models. Choose the library with
+the `NerLibrary` parameter and specify the model using either `SpacyModel` or
+`HFModel`.
+
 ## Response
 
 A JSON object containing the detected entities is returned:

--- a/services/anonymization/README.md
+++ b/services/anonymization/README.md
@@ -108,6 +108,21 @@ python -m spacy download en_core_web_lg
 If using EFS, copy the resulting model directory to the configured path so the
 function can load it at runtime.
 
+### Using HuggingFace models
+
+Set `NerLibrary=hf` and provide the desired transformer via `HFModel` to use a
+HuggingFace model instead of spaCy. Any model available on the HuggingFace Hub
+can be specified.
+
+Example:
+
+```bash
+sam deploy \
+  --template-file services/anonymization/template.yaml \
+  --stack-name anonymization \
+  --parameter-overrides NerLibrary=hf HFModel=dbmdz/bert-large-cased-finetuned-conll03-english
+```
+
 
 ## Local testing
 

--- a/services/anonymization/src/detect_sensitive_info_lambda.py
+++ b/services/anonymization/src/detect_sensitive_info_lambda.py
@@ -48,18 +48,7 @@ def _build_engine(spacy_env: str, hf_env: str) -> "AnalyzerEngine" | None:
     library = (
         get_config("NER_LIBRARY") or os.environ.get("NER_LIBRARY", "spacy")
     ).lower()
-    if library == "spacy":
-        model_name = (
-            get_config(spacy_env)
-            or os.environ.get(spacy_env)
-            or get_config("SPACY_MODEL")
-            or os.environ.get("SPACY_MODEL", "en_core_web_sm")
-        )
-        conf = {
-            "nlp_engine_name": "spacy",
-            "models": [{"lang_code": LANGUAGE, "model_name": model_name}],
-        }
-    else:
+    if library.startswith("hf"):
         model_name = (
             get_config(hf_env)
             or os.environ.get(hf_env)
@@ -68,6 +57,17 @@ def _build_engine(spacy_env: str, hf_env: str) -> "AnalyzerEngine" | None:
         )
         conf = {
             "nlp_engine_name": "transformers",
+            "models": [{"lang_code": LANGUAGE, "model_name": model_name}],
+        }
+    else:
+        model_name = (
+            get_config(spacy_env)
+            or os.environ.get(spacy_env)
+            or get_config("SPACY_MODEL")
+            or os.environ.get("SPACY_MODEL", "en_core_web_sm")
+        )
+        conf = {
+            "nlp_engine_name": "spacy",
             "models": [{"lang_code": LANGUAGE, "model_name": model_name}],
         }
 

--- a/services/anonymization/template.yaml
+++ b/services/anonymization/template.yaml
@@ -5,12 +5,18 @@ Description: Lambdas for detecting and anonymizing sensitive information.
 Parameters:
   NerLibrary:
     Type: String
+    Description: NLP library used for entity recognition.
+    AllowedValues:
+      - spacy
+      - hf
     Default: 'spacy'
   SpacyModel:
     Type: String
+    Description: spaCy model name when NerLibrary is "spacy".
     Default: 'en_core_web_sm'
   HFModel:
     Type: String
+    Description: HuggingFace model identifier when NerLibrary is "hf".
     Default: 'dslim/bert-base-NER'
   MedicalModel:
     Type: String

--- a/tests/test_detect_sensitive_engine.py
+++ b/tests/test_detect_sensitive_engine.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+import types
+
+
+def load_lambda(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _stub_presidio(monkeypatch, calls):
+    provider_mod = types.SimpleNamespace()
+
+    class FakeProvider:
+        def __init__(self, nlp_configuration):
+            calls['conf'] = nlp_configuration
+
+        def create_engine(self):
+            calls['created'] = True
+            return 'nlp'
+
+    provider_mod.NlpEngineProvider = FakeProvider
+
+    analyzer_mod = types.SimpleNamespace(
+        AnalyzerEngine=lambda nlp_engine=None, supported_languages=None: {
+            'engine': nlp_engine,
+            'langs': supported_languages,
+        }
+    )
+    monkeypatch.setitem(sys.modules, 'presidio_analyzer', analyzer_mod)
+    monkeypatch.setitem(sys.modules, 'presidio_analyzer.nlp_engine', provider_mod)
+
+
+def test_build_engine_spacy(monkeypatch):
+    module = load_lambda('detect_spacy', 'services/anonymization/src/detect_sensitive_info_lambda.py')
+    calls = {}
+    _stub_presidio(monkeypatch, calls)
+    monkeypatch.setenv('NER_LIBRARY', 'spacy')
+    monkeypatch.setenv('SPACY_MODEL', 'custom-model')
+    engine = module._build_engine('SPACY_MODEL', 'HF_MODEL')
+    assert calls['conf']['nlp_engine_name'] == 'spacy'
+    assert calls['conf']['models'][0]['model_name'] == 'custom-model'
+    assert engine['langs'] == [module.LANGUAGE]
+
+
+def test_build_engine_hf(monkeypatch):
+    module = load_lambda('detect_hf', 'services/anonymization/src/detect_sensitive_info_lambda.py')
+    calls = {}
+    _stub_presidio(monkeypatch, calls)
+    monkeypatch.setenv('NER_LIBRARY', 'hf')
+    monkeypatch.setenv('HF_MODEL', 'bert-base')
+    engine = module._build_engine('SPACY_MODEL', 'HF_MODEL')
+    assert calls['conf']['nlp_engine_name'] == 'transformers'
+    assert calls['conf']['models'][0]['model_name'] == 'bert-base'
+    assert engine['engine'] == 'nlp'
+
+


### PR DESCRIPTION
## Summary
- make NER parameters configurable in template
- allow `_build_engine` to detect HuggingFace models
- document HF model usage in service docs
- explain library selection in PII service guide
- test spaCy vs HuggingFace engine selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706e203234832f8a92cdf97ae7a7d5