### PR TITLE
Add file redaction Lambda

### DIFF
--- a/common/layers/file-redaction-lambda-layer/requirements.txt
+++ b/common/layers/file-redaction-lambda-layer/requirements.txt
@@ -1,0 +1,3 @@
+PyMuPDF
+Pillow
+boto3==1.35.53

--- a/docs/event_schemas.md
+++ b/docs/event_schemas.md
@@ -49,6 +49,16 @@ The IDP Lambdas are triggered by standard S3 events. Each event contains a list 
 }
 ```
 
+## File Redaction Payload
+
+```json
+{
+  "file": "s3://bucket/path/doc.pdf",
+  "hocr": {"documentId": "doc", "pages": []},
+  "entities": [{"text": "Jane", "type": "PERSON", "start": 0, "end": 4}]
+}
+```
+
 ## LLM Gateway Payload
 
 ```json

--- a/services/file-assembly/README.md
+++ b/services/file-assembly/README.md
@@ -1,9 +1,12 @@
 # File Assembly Service
 
-This service merges summary pages with the original PDF and uploads the merged result to Amazon S3.
+This service merges summary pages with the original PDF and uploads the merged
+result to Amazon S3. It also provides a Lambda for redacting detected PII in
+documents.
 
-- **Lambda**: `src/file_assembly_lambda.py`
-- **Layer**: `common/layers/file-assemble-lambda-layer/`
+- **Lambdas**: `src/file_assembly_lambda.py`, `src/redact_file_lambda.py`
+- **Layers**: `common/layers/file-assemble-lambda-layer/`,
+  `common/layers/file-redaction-lambda-layer/`
 
 The handler signatures reference dataclasses from ``models.py``:
 
@@ -13,7 +16,9 @@ The handler signatures reference dataclasses from ``models.py``:
 
 ## Environment variable
 
-`AWS_ACCOUNT_NAME` must be provided so resource names can be scoped to your AWS account.
+`AWS_ACCOUNT_NAME` must be provided so resource names can be scoped to your AWS
+account. The redaction Lambda also honours `REDACTED_PREFIX` to determine the
+upload location for redacted files.
 
 ## Deployment
 

--- a/services/file-assembly/src/redact_file_lambda.py
+++ b/services/file-assembly/src/redact_file_lambda.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+"""Redact PII regions in PDF or image files using bounding boxes.
+
+The Lambda accepts a JSON payload with these fields:
+
+- ``file`` – ``s3://`` URI of the source file to redact.
+- ``hocr`` – combined hOCR JSON with word bounding boxes.
+- ``entities`` – list of PII entities containing ``start`` and ``end`` offsets.
+
+The redacted file is written back to the same bucket under ``REDACTED_PREFIX``.
+"""
+
+import io
+import json
+import logging
+import os
+from typing import Any, Dict, Iterable, List
+
+import boto3
+from common_utils import configure_logger, get_config, lambda_response, parse_s3_uri
+from common_utils.error_utils import error_response, log_exception
+
+try:  # optional dependencies may be mocked in tests
+    import fitz  # type: ignore
+    from PIL import Image, ImageDraw
+except Exception:  # pragma: no cover - fallback stubs
+    fitz = None  # type: ignore
+    Image = ImageDraw = None  # type: ignore
+
+logger = configure_logger(__name__)
+
+s3_client = boto3.client("s3")
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _iter_words(hocr: Dict[str, Any]) -> Iterable[tuple[int, int, List[int]]]:
+    """Yield ``(offset, page_number, bbox)`` for each word in *hocr*."""
+
+    offset = 0
+    for page_idx, page in enumerate(hocr.get("pages", []), start=1):
+        words = page.get("words", [])
+        for word in words:
+            text = str(word.get("text", ""))
+            bbox = word.get("bbox")
+            if bbox and len(text) > 0:
+                for i in range(len(text)):
+                    yield offset + i, page_idx, bbox
+            offset += len(text) + 1  # space between words
+        offset += 1  # newline between pages
+
+
+def _map_boxes(hocr: Dict[str, Any], entities: List[Dict[str, Any]]) -> Dict[int, List[List[int]]]:
+    """Return mapping of page number to bounding boxes for ``entities``."""
+
+    index_map: Dict[int, tuple[int, List[int]]] = {}
+    for off, page, box in _iter_words(hocr):
+        index_map[off] = (page, box)
+
+    pages: Dict[int, List[List[int]]] = {}
+    for ent in entities:
+        start = int(ent.get("start", 0))
+        end = int(ent.get("end", start))
+        for i in range(start, end):
+            if i in index_map:
+                page, box = index_map[i]
+                pages.setdefault(page, []).append(box)
+    for page, box_list in pages.items():
+        unique = []
+        for b in box_list:
+            if b not in unique:
+                unique.append(b)
+        pages[page] = unique
+    return pages
+
+
+def _redact_pdf(data: bytes, boxes: Dict[int, List[List[int]]]) -> bytes:
+    """Return PDF bytes with ``boxes`` obscured."""
+
+    if not fitz:  # pragma: no cover - dependency missing
+        return data
+    with fitz.open(stream=data, filetype="pdf") as doc:
+        for page_idx, page in enumerate(doc, start=1):
+            for bbox in boxes.get(page_idx, []):
+                rect = fitz.Rect(*bbox)
+                page.draw_rect(rect, color=(1, 1, 1), fill=(1, 1, 1))
+        out = io.BytesIO()
+        doc.save(out)
+    return out.getvalue()
+
+
+def _redact_image(data: bytes, boxes: List[List[int]]) -> bytes:
+    """Return image bytes with ``boxes`` obscured."""
+
+    if not Image:  # pragma: no cover - dependency missing
+        return data
+    with Image.open(io.BytesIO(data)) as img:
+        draw = ImageDraw.Draw(img)
+        for bbox in boxes:
+            draw.rectangle(bbox, fill="white")
+        out = io.BytesIO()
+        img.save(out, format=img.format or "PNG")
+    return out.getvalue()
+
+
+def _redact_and_upload(bucket: str, key: str, hocr: Dict[str, Any], entities: List[Dict[str, Any]]) -> Dict[str, str]:
+    """Redact ``key`` in ``bucket`` and upload the result."""
+
+    dest_prefix = get_config("REDACTED_PREFIX", bucket, key) or os.environ.get("REDACTED_PREFIX", "redacted/")
+    if dest_prefix and not dest_prefix.endswith("/"):
+        dest_prefix += "/"
+    dest_key = dest_prefix + os.path.basename(key)
+
+    obj = s3_client.get_object(Bucket=bucket, Key=key)
+    body = obj["Body"].read()
+
+    boxes = _map_boxes(hocr, entities)
+    ext = os.path.splitext(key)[1].lower()
+    if ext == ".pdf":
+        redacted = _redact_pdf(body, boxes)
+        content_type = "application/pdf"
+    else:
+        page_boxes = boxes.get(1, [])
+        redacted = _redact_image(body, page_boxes)
+        content_type = obj.get("ContentType") or "image/png"
+
+    s3_client.put_object(Bucket=bucket, Key=dest_key, Body=redacted, ContentType=content_type)
+    logger.info("Wrote %s", dest_key)
+    return {"redacted_file": f"s3://{bucket}/{dest_key}"}
+
+
+# ---------------------------------------------------------------------------
+# Lambda handler
+# ---------------------------------------------------------------------------
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Entry point for the file redaction Lambda."""
+
+    try:
+        body = event.get("body", event)
+        file_uri = body.get("file")
+        if not file_uri:
+            raise ValueError("file missing from event")
+        hocr = body.get("hocr")
+        if isinstance(hocr, str):
+            hocr = json.loads(hocr)
+        entities = body.get("entities", [])
+        bucket, key = parse_s3_uri(file_uri)
+        result = _redact_and_upload(bucket, key, hocr or {}, entities)
+        return lambda_response(200, result)
+    except Exception as exc:
+        log_exception("File redaction failed", exc, logger)
+        return error_response(logger, 500, "Redaction failed", exc)

--- a/services/file-assembly/template.yaml
+++ b/services/file-assembly/template.yaml
@@ -31,6 +31,10 @@ Parameters:
   LambdaIAMRoleARN:
     Type: String
     Description: IAM Role ARN for Lambda functions
+  RedactedPrefix:
+    Type: String
+    Default: redacted/
+    Description: Prefix where redacted files are stored
 
 Resources:
   FileAssembleLambdaLayer:
@@ -50,6 +54,16 @@ Resources:
       CompatibleRuntimes:
         - python3.13
       RetentionPolicy: Delete
+
+  FileRedactionLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: !Sub '${AWSAccountName}-${AWS::StackName}-file-redaction-layer'
+      Description: Layer for file redaction Lambda
+      ContentUri: ../../common/layers/file-redaction-lambda-layer/
+      RetentionPolicy: Delete
+      CompatibleRuntimes:
+        - python3.13
 
   FileAssembleLambdaFunction:
     Type: AWS::Serverless::Function
@@ -77,7 +91,36 @@ Resources:
         Variables:
           AWS_ACCOUNT_NAME: !Ref AWSAccountName
 
+  FileRedactionLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub '${AWSAccountName}-${AWS::StackName}-file-redaction'
+      Handler: redact_file_lambda.lambda_handler
+      Runtime: python3.13
+      CodeUri: ./src/
+      Role: !Ref LambdaIAMRoleARN
+      MemorySize: 1024
+      Timeout: 600
+      EphemeralStorage:
+        Size: 2068
+      Layers:
+        - !Ref FileRedactionLayer
+        - !Ref CommonUtilsLayer
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroupID1
+          - !Ref LambdaSecurityGroupID2
+        SubnetIds:
+          - !Ref LambdaSubnet1ID
+          - !Ref LambdaSubnet2ID
+      Environment:
+        Variables:
+          REDACTED_PREFIX: !Ref RedactedPrefix
+
 Outputs:
   FileAssembleFunctionArn:
     Description: ARN of the file assemble Lambda
     Value: !GetAtt FileAssembleLambdaFunction.Arn
+  FileRedactionFunctionArn:
+    Description: ARN of the file redaction Lambda
+    Value: !GetAtt FileRedactionLambdaFunction.Arn

--- a/tests/test_redact_file_lambda.py
+++ b/tests/test_redact_file_lambda.py
@@ -1,0 +1,73 @@
+import importlib.util
+import io
+import types
+import importlib.util
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'common', 'layers', 'common-utils', 'python'))
+
+from models import DetectedEntity
+
+
+def load_lambda(name):
+    spec = importlib.util.spec_from_file_location(name, 'services/file-assembly/src/redact_file_lambda.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_map_boxes():
+    module = load_lambda('redact')
+    hocr = {"pages": [{"words": [
+        {"text": "Hello", "bbox": [0, 0, 5, 5]},
+        {"text": "World", "bbox": [6, 0, 10, 5]},
+    ]}]}
+    entities = [DetectedEntity(text='Hello', type='PERSON', start=0, end=5).__dict__]
+    boxes = module._map_boxes(hocr, entities)
+    assert boxes == {1: [[0, 0, 5, 5]]}
+
+
+def test_redact_image(monkeypatch, s3_stub):
+    module = load_lambda('redact_img')
+
+    class DummyImage:
+        def __init__(self):
+            self.drawn = []
+            self.format = 'PNG'
+
+        def save(self, out, format=None):
+            out.write(b'data')
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class DummyDraw:
+        def __init__(self, img):
+            self.img = img
+        def rectangle(self, bbox, fill=None):
+            self.img.drawn.append(bbox)
+
+    last = {}
+    def open_stub(fh):
+        img = DummyImage()
+        last['img'] = img
+        return img
+    monkeypatch.setattr(module, 'Image', types.SimpleNamespace(open=open_stub))
+    monkeypatch.setattr(module, 'ImageDraw', types.SimpleNamespace(Draw=DummyDraw))
+    monkeypatch.setattr(module, 's3_client', s3_stub)
+
+    img_bytes = b'img'
+    s3_stub.objects[('bucket', 'file.png')] = img_bytes
+
+    event = {
+        'file': 's3://bucket/file.png',
+        'hocr': {'pages': [{'words': [{'text': 'a', 'bbox': [0, 0, 1, 1]}]}]},
+        'entities': [{'text': 'a', 'type': 'CHAR', 'start': 0, 'end': 1}],
+    }
+    resp = module.lambda_handler(event, {})
+    assert resp['statusCode'] == 200
+    assert ('bucket', 'redacted/file.png') in s3_stub.objects
+    assert last['img'].drawn == [[0, 0, 1, 1]]


### PR DESCRIPTION
## Summary
- add `redact_file_lambda.py` for drawing redaction boxes over PII
- package Pillow/PyMuPDF dependencies in new layer
- define `FileRedactionLambdaFunction` in SAM template
- document redaction payload schema
- test coordinate mapping and image redaction logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870764ea538832f915fc04c824e6657