### PR TITLE
Add redaction service outputs

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -137,6 +137,7 @@ Resources:
         DetectPiiFunctionArn: !GetAtt AnonymizationService.Outputs.DetectSensitiveInfoFunctionArn
         SourceBucket: !GetAtt IDPService.Outputs.BucketName
         SourcePrefix: redact/
+        OcrRequestQueueArn: !GetAtt IDPService.Outputs.OcrRequestQueueArn
 
 Outputs:
   FileIngestionStateMachineArn:
@@ -157,4 +158,10 @@ Outputs:
   DocumentAuditTableName:
     Description: Name of the document audit table
     Value: !GetAtt FileIngestionService.Outputs.DocumentAuditTableName
+  RedactionFunctionArn:
+    Description: ARN of the redaction orchestrator Lambda
+    Value: !GetAtt RedactionService.Outputs.RedactionOrchestratorFunctionArn
+  RedactionStatusTableName:
+    Description: Name of the redaction status table
+    Value: !GetAtt RedactionService.Outputs.RedactionStatusTableName
 


### PR DESCRIPTION
## Summary
- wire up the redaction service queue ARN in the parent stack
- export the redaction function and table from the parent stack

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707b76316c832fa38d004e402361dd