### PR TITLE
Add redaction workflow diagram

### DIFF
--- a/services/redaction/README.md
+++ b/services/redaction/README.md
@@ -13,6 +13,17 @@ performs the following steps:
 4. **Invoke file redaction** – the original file, hOCR output and detected
    entities are forwarded to the file redaction Lambda.
 
+### Workflow Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> CopyToIDP
+    CopyToIDP --> WaitForOcr
+    WaitForOcr --> DetectPII
+    DetectPII --> FileRedaction
+    FileRedaction --> [*]
+```
+
 Status updates are stored in the ``RedactionStatusTable`` DynamoDB table.
 Each document record includes a ``status`` attribute with one of
 ``PENDING``, ``IN_PROGRESS``, ``FAILED`` or ``COMPLETED``. When


### PR DESCRIPTION
## Summary
- include a Mermaid state diagram in `services/redaction/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68708515599c832f8716db66ae3d145d