### PR TITLE
Update IDP diagram for hOCR output

### DIFF
--- a/services/idp/README.md
+++ b/services/idp/README.md
@@ -48,12 +48,13 @@ flowchart LR
     A["Upload to RAW_PREFIX"] --> B(classifier)
     B -- "DOCX/PPTX/XLSX" --> C(office-extractor)
     B -- "PDF" --> D(pdf-split)
-    D --> E(pdf-page-classifier)
+    D -- "page_NNN.pdf + manifest.json" --> E(pdf-page-classifier)
     E -- "text page" --> F(pdf-text-extractor)
     E -- "scan page" --> G(pdf-ocr-extractor)
     C --> H(combine)
     F --> H
     G --> H
+    G -- "hOCR (ocrmypdf)" --> J(HOCR_PREFIX)
     H --> I(output)
 ```
 


### PR DESCRIPTION
## Summary
- illustrate hOCR output in the IDP workflow diagram
- show page numbering from pdf-split to pdf-page-classifier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68708bb49d64832f8428c02919b0fdcc