### PR TITLE
Add hOCR output to IDP workflow

### DIFF
--- a/services/idp/README.md
+++ b/services/idp/README.md
@@ -26,14 +26,36 @@ All handlers accept the :class:`models.S3Event` dataclass and return a
    embedded text from pages under `PAGE_PREFIX` and stores Markdown
    output in `TEXT_PREFIX`.
 6. **pdf-ocr-extractor** – `src/pdf_ocr_extractor_lambda.py` performs OCR
-   on scanned pages using the engine specified by `OCR_ENGINE` and writes
-   results to `OCR_PREFIX`.
+   on scanned pages using the engine specified by `OCR_ENGINE`. Markdown
+   results are written to `OCR_PREFIX` and, when the `ocrmypdf` engine is
+   used, word bounding boxes are stored under `HOCR_PREFIX`.
 7. **combine** – `src/combine_lambda.py` waits until all page outputs
    exist and combines them into a single JSON document under
    `COMBINE_PREFIX` / `TEXT_DOC_PREFIX`.
 8. **output** – `src/output_lambda.py` posts the final JSON from
    `TEXT_DOC_PREFIX` to an external API and stores any response under
    `OUTPUT_PREFIX`.
+
+The relationships between file types and Lambda functions are illustrated
+in the following diagram.
+
+```mermaid
+flowchart LR
+    A["Upload to RAW_PREFIX"] --> B(classifier)
+    B -- "DOCX/PPTX/XLSX" --> C(office-extractor)
+    B -- "PDF" --> D(pdf-split)
+    D --> E(pdf-page-classifier)
+    subgraph "per-page lambdas"
+        direction TB
+        E -- "text page" --> F(pdf-text-extractor)
+        E -- "scan page" --> G(pdf-ocr-extractor)
+        G --> J[hOCR JSON]
+    end
+    C --> H(combine)
+    F --> H
+    G --> H
+    H --> I(output)
+```
 
 ## Environment variables
 
@@ -51,6 +73,7 @@ helper. Key variables include:
 - `PAGE_PREFIX` – prefix containing individual page PDFs.
 - `TEXT_PREFIX` – prefix for Markdown created from text-based pages.
 - `OCR_PREFIX` – prefix for OCR results.
+- `HOCR_PREFIX` – prefix for hOCR JSON word boxes.
 - `COMBINE_PREFIX` – location where combined page results are emitted.
 - `OUTPUT_PREFIX` – final output prefix used by the output Lambda.
 - `TEXT_DOC_PREFIX` – prefix for the merged document JSON files.


### PR DESCRIPTION
## Summary
- expand IDP workflow description with HOCR output
- include `HOCR_PREFIX` in environment variables
- update the Mermaid diagram to show hOCR JSON generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870871830e8832f93629f7b7e89ff98