### PR TITLE
Add mail room redaction use case

### DIFF
--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -6,6 +6,7 @@ Use case workflows built from the AI services in this repository live in this di
 |--------------------|-------------|
 | **aps-summarization** | Processes an uploaded ZIP of Attending Physician Statements and generates summarized PDFs bundled in a new archive. |
 | **legal-redaction** | Redacts subpoena PDFs using OCR, PII detection and PDF assembly. |
+| **mail-room-redaction** | Sanitizes incoming mail room letters using OCR, PII detection and PDF assembly. |
 
 Additional use cases can be added following the same structure with their own `README.md` and deployment template.
 

--- a/use-cases/mail-room-redaction/README.md
+++ b/use-cases/mail-room-redaction/README.md
@@ -1,0 +1,101 @@
+# Mail Room Redaction Workflow
+
+This example deploys the IDP, anonymization and redaction services to sanitize
+letters uploaded to the Ameritas mail room. Incoming PDFs are processed through
+OCR, PII/PHI is detected using configurable regex patterns and the final
+redacted file is written back to S3.
+
+## Workflow
+
+```mermaid
+flowchart LR
+    A["Upload PDF to redact/ prefix"] --> B(Redaction orchestrator)
+    B --> C[Copy to IDP bucket]
+    C --> D(IDP OCR pipeline)
+    D --> E[Extracted text & hOCR]
+    E --> F[/detect-pii API/]
+    F --> G(File redaction Lambda)
+    G --> H[Redacted PDF in S3]
+    G --> I[Update status table]
+```
+
+## Configuration
+
+The anonymization service reads configuration from Parameter Store or the Lambda
+environment. Populate these variables before deployment:
+
+- `NER_LIBRARY` and related model variables (`SPACY_MODEL` or `HF_MODEL`)
+- `REGEX_PATTERNS` – JSON map of custom detectors
+- `ANON_MODE` – `mask`, `pseudo` or `token`
+- Deterministic pseudonymization may require modifying
+  `mask_text_lambda.py` to reuse replacements for repeated entities
+  within the same document.
+
+Create parameters named as above under `/parameters/aio/ameritasAI/<ENV>/` or
+export them as environment variables. See
+[services/anonymization/README.md](../../services/anonymization/README.md) and
+[docs/environment_variables.md](../../docs/environment_variables.md#sensitive-info-detection)
+for details.
+
+## Deployment
+
+Deploy all required services with SAM. The stack parameters provide network and
+IAM settings shared by each nested application. `RegexPatterns` should contain a
+JSON map of custom detectors for the anonymization service. A sample file is
+included under `config/mailroom_regex_patterns.json`.
+
+```bash
+sam deploy \
+  --template-file use-cases/mail-room-redaction/template.yaml \
+  --stack-name mail-room-redaction \
+  --parameter-overrides \
+    AWSAccountName=<name> \
+    LambdaIAMRoleARN=<role-arn> \
+    LambdaSubnet1ID=<subnet1> \
+    LambdaSubnet2ID=<subnet2> \
+    LambdaSecurityGroupID1=<sg1> \
+    LambdaSecurityGroupID2=<sg2> \
+    RegexPatterns="$(cat use-cases/mail-room-redaction/config/mailroom_regex_patterns.json)"
+```
+
+## Uploading mail room letters
+
+Letters can be submitted either via the ingestion API or by uploading
+directly to the IDP bucket. The SAM template connects the Redaction Service to
+`s3:ObjectCreated:*` events so any file placed under the configured
+`SourcePrefix` (default `redact/`) triggers the orchestrator:
+
+```yaml
+SourceBucket: !Ref IdpBucketName
+SourcePrefix: redact/
+Events:
+  Upload:
+    Type: S3
+    Properties:
+      Bucket: !Ref SourceBucket
+      Events: s3:ObjectCreated:*
+      Filter:
+        S3Key:
+          Rules:
+            - Name: prefix
+              Value: !Ref SourcePrefix
+```
+
+When the event fires, the workflow copies the uploaded PDF to the IDP bucket so
+OCR can run before redaction begins.
+
+## Retrieving redacted PDFs
+
+Documents uploaded via either method are copied to the IDP bucket for OCR
+extraction. Once processing is complete the `redact_file_lambda` from
+**file-assembly** writes the PDF back to the same bucket using the prefix from
+the `REDACTED_PREFIX` environment variable (see
+[services/file-assembly/README.md](../../services/file-assembly/README.md#environment-variable)).
+Locate the final PDF at:
+
+```
+s3://<IDP bucket>/<RedactedPrefix><original filename>
+```
+
+The associated DynamoDB table exported as `RedactionStatusTableName` records the
+processing status for each document.

--- a/use-cases/mail-room-redaction/config/mailroom_regex_patterns.json
+++ b/use-cases/mail-room-redaction/config/mailroom_regex_patterns.json
@@ -1,0 +1,4 @@
+{
+  "POLICY_NUMBER": "\\b[A-Z]{2}\\d{6}\\b",
+  "ACCOUNT_NO": "\\b\d{3}-\d{2}-\d{4}\\b"
+}

--- a/use-cases/mail-room-redaction/template.yaml
+++ b/use-cases/mail-room-redaction/template.yaml
@@ -1,0 +1,115 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Deploy services for Ameritas Mail Room redaction
+
+Globals:
+  Function:
+    Timeout: 3
+    Tracing: Active
+    Runtime: python3.13
+    Architectures:
+      - x86_64
+    LoggingConfig:
+      LogFormat: JSON
+
+Parameters:
+  AWSAccountName:
+    Type: String
+  LambdaIAMRoleARN:
+    Type: String
+  LambdaSubnet1ID:
+    Type: String
+  LambdaSubnet2ID:
+    Type: String
+  LambdaSecurityGroupID1:
+    Type: String
+  LambdaSecurityGroupID2:
+    Type: String
+  IdpBucketName:
+    Type: String
+  RegexPatterns:
+    Type: String
+    Default: '{}'
+
+Resources:
+  NoOpStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Definition:
+        StartAt: Done
+        States:
+          Done:
+            Type: Pass
+            End: true
+      Role: !Ref LambdaIAMRoleARN
+      Type: STANDARD
+
+  FileAssemblyService:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../../services/file-assembly/template.yaml
+      Parameters:
+        AWSAccountName: !Ref AWSAccountName
+        LambdaSubnet1ID: !Ref LambdaSubnet1ID
+        LambdaSubnet2ID: !Ref LambdaSubnet2ID
+        LambdaSecurityGroupID1: !Ref LambdaSecurityGroupID1
+        LambdaSecurityGroupID2: !Ref LambdaSecurityGroupID2
+        LambdaIAMRoleARN: !Ref LambdaIAMRoleARN
+
+  FileIngestionService:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../../services/file-ingestion/template.yaml
+      Parameters:
+        AWSAccountName: !Ref AWSAccountName
+        LambdaSubnet1ID: !Ref LambdaSubnet1ID
+        LambdaSubnet2ID: !Ref LambdaSubnet2ID
+        LambdaSecurityGroupID1: !Ref LambdaSecurityGroupID1
+        LambdaSecurityGroupID2: !Ref LambdaSecurityGroupID2
+        LambdaIAMRoleARN: !Ref LambdaIAMRoleARN
+        FileIngestionStateMachineIAMRole: !Ref LambdaIAMRoleARN
+        IDPBucketName: !Ref IdpBucketName
+        IngestionStateMachineArn: !Ref NoOpStateMachine
+
+  IDPService:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../../services/idp/template.yaml
+      Parameters:
+        BUCKET_NAME: !Ref IdpBucketName
+        DocumentAuditTableName: !GetAtt FileIngestionService.Outputs.DocumentAuditTableName
+
+  AnonymizationService:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../../services/anonymization/template.yaml
+      Parameters:
+        RegexPatterns: !Ref RegexPatterns
+
+  RedactionService:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../../services/redaction/template.yaml
+      Parameters:
+        AWSAccountName: !Ref AWSAccountName
+        LambdaSubnet1ID: !Ref LambdaSubnet1ID
+        LambdaSubnet2ID: !Ref LambdaSubnet2ID
+        LambdaSecurityGroupID1: !Ref LambdaSecurityGroupID1
+        LambdaSecurityGroupID2: !Ref LambdaSecurityGroupID2
+        LambdaIAMRoleARN: !Ref LambdaIAMRoleARN
+        FileRedactionFunctionArn: !GetAtt FileAssemblyService.Outputs.FileRedactionFunctionArn
+        DetectPiiFunctionArn: !GetAtt AnonymizationService.Outputs.DetectSensitiveInfoFunctionArn
+        SourceBucket: !Ref IdpBucketName
+        SourcePrefix: redact/
+        OcrRequestQueueArn: !GetAtt IDPService.Outputs.OcrRequestQueueArn
+
+Outputs:
+  BucketName:
+    Description: Name of the IDP bucket containing redacted files
+    Value: !Ref IdpBucketName
+  RedactionStatusTableName:
+    Description: Name of the redaction status table
+    Value: !GetAtt RedactionService.Outputs.RedactionStatusTableName
+  RedactionFunctionArn:
+    Description: ARN of the redaction orchestrator Lambda
+    Value: !GetAtt RedactionService.Outputs.RedactionOrchestratorFunctionArn


### PR DESCRIPTION
## Summary
- add new use case `mail-room-redaction`
- include SAM template and example regex patterns
- document mail room redaction workflow
- list new use case in overview README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b022128c832fbeb31a1aad026255