### PR TITLE
Add ACORD XML generator service

### DIFF
--- a/services/acord-generator/README.md
+++ b/services/acord-generator/README.md
@@ -1,0 +1,31 @@
+# ACORD XML Generator Service
+
+This service converts extracted document data into a simplified
+ACORD 103 XML payload.  It is typically invoked after OCR extraction
+and field detection have completed.
+
+The Lambda expects a JSON event with the following keys:
+
+- **fields** – mapping of ACORD tag names to the extracted text values.
+- **signatures** – optional mapping of signer roles to the signer name or
+  timestamp.
+
+The function returns the generated XML string in the `body` of the
+Lambda response.
+
+Example output for a minimal payload might look like:
+
+```xml
+<ACORD>
+  <InsuranceSvcRq>
+    <PolNumber>PN123</PolNumber>
+    <Signatures>
+      <Insured>John Doe</Insured>
+    </Signatures>
+  </InsuranceSvcRq>
+</ACORD>
+```
+
+The accompanying `template.yaml` defines the Lambda function and a
+parameter for the CaseImport API endpoint used by downstream
+integrations.

--- a/services/acord-generator/src/generate_xml_lambda.py
+++ b/services/acord-generator/src/generate_xml_lambda.py
@@ -1,0 +1,56 @@
+# ------------------------------------------------------------------------------
+# generate_xml_lambda.py
+# ------------------------------------------------------------------------------
+"""Generate ACORD 103 XML from extracted data.
+
+The Lambda expects a JSON payload with two top level keys:
+``fields``
+    Mapping of field names to values extracted from the document.
+``signatures``
+    Mapping of signature roles to the signer name or timestamp.
+
+The handler returns a simple ACORD 103 document in XML form.
+"""
+
+from __future__ import annotations
+
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+
+def generate_acord_xml(data: dict) -> str:
+    """Convert field data into an ACORD 103 ``InsuranceSvcRq``.
+
+    Parameters
+    ----------
+    data:
+        Dictionary containing ``fields`` and ``signatures`` mappings.
+
+    Returns
+    -------
+    str
+        The generated XML string.
+    """
+
+    fields = data.get("fields") or {}
+    signatures = data.get("signatures") or {}
+
+    root = Element("ACORD")
+    rq = SubElement(root, "InsuranceSvcRq")
+
+    for key, value in fields.items():
+        child = SubElement(rq, key)
+        child.text = str(value)
+
+    if signatures:
+        sig_el = SubElement(rq, "Signatures")
+        for role, value in signatures.items():
+            sub = SubElement(sig_el, role)
+            sub.text = str(value)
+
+    return tostring(root, encoding="unicode")
+
+
+def lambda_handler(event, context):  # pragma: no cover - thin wrapper
+    """AWS Lambda entry point."""
+    xml = generate_acord_xml(event)
+    return {"statusCode": 200, "body": xml}

--- a/services/acord-generator/template.yaml
+++ b/services/acord-generator/template.yaml
@@ -1,0 +1,54 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Generate ACORD 103 XML from extracted data.
+
+Parameters:
+  AWSAccountName:
+    Type: String
+  LambdaSubnet1ID:
+    Type: String
+  LambdaSubnet2ID:
+    Type: String
+  LambdaSecurityGroupID1:
+    Type: String
+  LambdaSecurityGroupID2:
+    Type: String
+  LambdaIAMRoleARN:
+    Type: String
+  CaseImportEndpoint:
+    Type: String
+    Description: API endpoint for CaseImport service
+
+Globals:
+  Function:
+    Timeout: 10
+    Runtime: python3.13
+    Tracing: Active
+    LoggingConfig:
+      LogFormat: JSON
+
+Resources:
+  AcordGeneratorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub '${AWSAccountName}-${AWS::StackName}-acord-generator'
+      Handler: generate_xml_lambda.lambda_handler
+      CodeUri: ./src/
+      Runtime: python3.13
+      Role: !Ref LambdaIAMRoleARN
+      MemorySize: 512
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroupID1
+          - !Ref LambdaSecurityGroupID2
+        SubnetIds:
+          - !Ref LambdaSubnet1ID
+          - !Ref LambdaSubnet2ID
+      Environment:
+        Variables:
+          CASEIMPORT_ENDPOINT: !Ref CaseImportEndpoint
+
+Outputs:
+  AcordGeneratorFunctionArn:
+    Description: ARN of the ACORD generator Lambda
+    Value: !GetAtt AcordGeneratorFunction.Arn

--- a/tests/test_acord_generator.py
+++ b/tests/test_acord_generator.py
@@ -1,0 +1,21 @@
+import importlib.util
+
+
+def load_lambda(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_acord_xml():
+    module = load_lambda('acord', 'services/acord-generator/src/generate_xml_lambda.py')
+    data = {
+        'fields': {'PolNumber': 'PN123', 'InsuredName': 'Jane Doe'},
+        'signatures': {'Insured': 'Jane Doe', 'DateSigned': '2024-01-01'},
+    }
+    xml = module.generate_acord_xml(data)
+    assert '<PolNumber>PN123</PolNumber>' in xml
+    assert '<InsuredName>Jane Doe</InsuredName>' in xml
+    assert '<Insured>Jane Doe</Insured>' in xml
+    assert '<DateSigned>2024-01-01</DateSigned>' in xml


### PR DESCRIPTION
## Summary
- add ACORD XML generator service with Lambda code
- document input/output of generator
- provide CloudFormation template for deployment
- add unit test for XML generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b5aaa980832f8f0865c9270676c0